### PR TITLE
Refactor dashboard actions for stronger typing

### DIFF
--- a/features/dashboard/recent-alerts-widget.tsx
+++ b/features/dashboard/recent-alerts-widget.tsx
@@ -18,13 +18,7 @@ export default async function RecentAlertsWidget({ orgId }: RecentAlertsWidgetPr
   try {
     const result = await getDashboardAlertsAction(orgId);
     if (result.success && Array.isArray(result.data)) {
-      alerts = result.data.map((a: any) => ({
-        id: a.id,
-        message: a.message,
-        severity: a.severity as Alert["severity"],
-        timestamp: a.timestamp,
-        type: a.type ?? "other",
-      }));
+      alerts = result.data;
     }
   } catch (e) {
     alerts = [];

--- a/features/dashboard/todays-schedule-widget.tsx
+++ b/features/dashboard/todays-schedule-widget.tsx
@@ -22,13 +22,7 @@ export default async function TodaysScheduleWidget({ orgId }: TodaysScheduleWidg
   try {
     const result = await getTodaysScheduleAction(orgId);
     if (result.success && Array.isArray(result.data)) {
-      scheduleItems = result.data.map((item: any) => ({
-        id: item.id,
-        description: item.description,
-        timePeriod: item.timePeriod || "Today",
-        count: item.count ?? 0,
-        type: item.type ?? "none",
-      }));
+      scheduleItems = result.data;
     }
   } catch (e) {
     scheduleItems = [];

--- a/lib/actions/dashboardActions.ts
+++ b/lib/actions/dashboardActions.ts
@@ -5,8 +5,9 @@ import { revalidatePath } from "next/cache";
 import prisma from "@/lib/database/db";
 import { hasPermission } from "@/lib/auth/permissions";
 import { getOrganizationKPIs } from "@/lib/fetchers/kpiFetchers";
+import type { OrganizationKPIs } from "@/types/kpi";
 
-export interface DashboardActionResult<T = any> {
+export interface DashboardActionResult<T = unknown> {
   success: boolean;
   error?: string;
   data?: T;
@@ -15,7 +16,7 @@ export interface DashboardActionResult<T = any> {
 /**
  * Get dashboard overview statistics
  */
-export async function getDashboardOverviewAction(): Promise<DashboardActionResult> {
+export async function getDashboardOverviewAction(): Promise<DashboardActionResult<OrganizationKPIs>> {
   try {
     const { userId } = await auth();
     if (!userId) {
@@ -378,7 +379,7 @@ export async function getTodaysScheduleAction(organizationId: string): Promise<D
 /**
  * Refresh dashboard data
  */
-export async function refreshDashboardAction(): Promise<DashboardActionResult> {
+export async function refreshDashboardAction(): Promise<DashboardActionResult<{ message: string }>> {
   try {
     const { userId } = await auth();
     if (!userId) {


### PR DESCRIPTION
## Summary
- use `unknown` as default generic for `DashboardActionResult`
- type dashboard action results with explicit generics
- clean up consumer widgets to use typed data

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684360bb2ed483278b265efc42fb55a6