### PR TITLE
Implement invitation revocation

### DIFF
--- a/components/settings/user-settings.tsx
+++ b/components/settings/user-settings.tsx
@@ -23,7 +23,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { MoreHorizontal, Plus, Search, Mail, Users, UserCheck, Loader2 } from "lucide-react"
 import { toast } from "@/hooks/use-toast"
 import { SystemRoles, type SystemRole } from "@/types/abac"
-import { createOrganizationInvitation, getOrganizationInvitations, type InvitationData } from "@/lib/actions/invitationActions"
+import { createOrganizationInvitation, getOrganizationInvitations, revokeOrganizationInvitation, type InvitationData } from "@/lib/actions/invitationActions"
 
 interface OrganizationInvitation {
   id: string
@@ -87,10 +87,14 @@ export function UserSettings() {
 
     setLoadingInvitations(true)
     try {
-      const result = await getOrganizationInvitations(user.publicMetadata.organizationId as string)
-      // Note: Since Clerk doesn't provide direct invitation listing, we'll show a placeholder
-      // In a real implementation, you'd track invitations in your own database
-      setInvitations([])
+      const result = await getOrganizationInvitations(
+        user.publicMetadata.organizationId as string
+      )
+      if (success(result)) {
+        setInvitations(result.invitations as OrganizationInvitation[])
+      } else {
+        setInvitations([])
+      }
     } catch (error) {
       console.error("Error loading invitations:", error)
       setInvitations([])
@@ -108,12 +112,9 @@ export function UserSettings() {
 
   const handleRevokeInvitation = async (invitationId: string) => {
     try {
-      // TODO: Implement actual revoke logic here, e.g. call an API or action
-      // Example:
-      // const result = await revokeOrganizationInvitation(invitationId)
-      const result = { success: false, error: "Revoke not implemented" } // Placeholder
+      const result = await revokeOrganizationInvitation(invitationId)
 
-      if (result.success) {
+      if (success(result)) {
         toast({
           title: "Invitation Revoked",
           description: "The invitation has been successfully revoked.",
@@ -122,7 +123,8 @@ export function UserSettings() {
       } else {
         toast({
           title: "Failed to Revoke Invitation",
-          description: result.error || "An error occurred while revoking the invitation.",
+          description:
+            result?.error || "An error occurred while revoking the invitation.",
           variant: "destructive",
         })
       }

--- a/lib/actions/invitationActions.ts
+++ b/lib/actions/invitationActions.ts
@@ -1,8 +1,8 @@
 
 'use server';
 
+import { clerkClient } from "@clerk/nextjs/server";
 import { auth } from '@clerk/nextjs/server';
-import { clerkClient } from '@clerk/nextjs/server';
 import { revalidatePath } from 'next/cache';
 
 export interface InvitationData {
@@ -14,19 +14,26 @@ export interface InvitationData {
 export async function createOrganizationInvitation(data: InvitationData) {
   try {
     const { userId, orgId } = await auth();
-    
+
     if (!userId || !orgId) {
       return { success: false, error: 'Unauthorized' };
     }
 
+    await clerkClient.organizations.createOrganizationInvitation({
+      organizationId: orgId,
+      inviterUserId: userId,
+      emailAddress: data.emailAddress,
+      role: data.role,
+      redirectUrl: data.redirectUrl,
+    });
 
     revalidatePath('/[orgId]/settings', 'page');
-  
+    return { success: true };
   } catch (error) {
     console.error('Error creating organization invitation:', error);
-    return { 
-      success: false, 
-      error: error instanceof Error ? error.message : 'Failed to create invitation' 
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to create invitation'
     };
   }
 }
@@ -35,25 +42,49 @@ export async function getOrganizationInvitations(organizationId?: string) {
   try {
     const { userId, orgId } = await auth();
     const targetOrgId = organizationId || orgId;
-    
+
     if (!userId || !targetOrgId) {
       return { success: false, error: 'Unauthorized' };
     }
 
-  
-    
+    const result = await clerkClient.organizations.getOrganizationInvitationList({
+      organizationId: targetOrgId,
+    });
 
+    return { success: true, invitations: result.data };
   } catch (error) {
     console.error('Error getting organization invitations:', error);
-    return { 
-      success: false, 
-      error: error instanceof Error ? error.message : 'Failed to get invitations' 
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to get invitations'
     };
   }
+}
+export async function revokeOrganizationInvitation(
+  invitationId: string,
+  organizationId?: string
+) {
+  try {
+    const { userId, orgId } = await auth();
+    const targetOrgId = organizationId || orgId;
 
+    if (!userId || !targetOrgId) {
+      return { success: false, error: 'Unauthorized' };
+    }
 
+    await clerkClient.organizations.revokeOrganizationInvitation({
+      organizationId: targetOrgId,
+      invitationId,
+      requestingUserId: userId,
+    });
 
-
-  
-
+    revalidatePath('/[orgId]/settings', 'page');
+    return { success: true };
+  } catch (error) {
+    console.error('Error revoking organization invitation:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to revoke invitation'
+    };
+  }
 }


### PR DESCRIPTION
## Summary
- enable revoking organization invitations via Clerk API
- display invitation list from server response
- hook up revoke action in user settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843602877888327864df1c3e5e4347c