### PR TITLE
Implement signed document upload flow

### DIFF
--- a/app/(tenant)/[orgId]/drivers/[userId]/page.tsx
+++ b/app/(tenant)/[orgId]/drivers/[userId]/page.tsx
@@ -128,7 +128,11 @@ export default async function DriverDashboardPage({ params }: { params: Promise<
             <CardDescription>Upload a new document for this driver</CardDescription>
           </CardHeader>
           <CardContent>
-            <DocumentUploadForm onUpload={() => {}} />
+            <DocumentUploadForm
+              entityType="driver"
+              entityId={driverData.id}
+              onUpload={() => {}}
+            />
           </CardContent>
         </Card>
       </div>


### PR DESCRIPTION
## Summary
- add server action to generate Vercel Blob upload URLs
- enhance `DocumentUploadForm` to use signed URL logic and accept dynamic entity data
- wire up driver dashboard page to pass entity details

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68436006dbbc8327aa3f76da65bef290