### PR TITLE
Enable signed uploads for compliance docs

### DIFF
--- a/app/(tenant)/[orgId]/drivers/[userId]/page.tsx
+++ b/app/(tenant)/[orgId]/drivers/[userId]/page.tsx
@@ -128,7 +128,11 @@ export default async function DriverDashboardPage({ params }: { params: Promise<
             <CardDescription>Upload a new document for this driver</CardDescription>
           </CardHeader>
           <CardContent>
-            <DocumentUploadForm onUpload={() => {}} />
+            <DocumentUploadForm
+              onUpload={() => {}}
+              entityType="driver"
+              entityId={driverData.id}
+            />
           </CardContent>
         </Card>
       </div>


### PR DESCRIPTION
## Summary
- add server action to generate signed upload tokens
- update `DocumentUploadForm` to use tokens and accept dynamic IDs
- pass driver details to `DocumentUploadForm`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68435fe965cc8327b676f6b7460cffca