### PR TITLE
Complete driver list page and create form

### DIFF
--- a/app/(tenant)/[orgId]/drivers/page.tsx
+++ b/app/(tenant)/[orgId]/drivers/page.tsx
@@ -1,18 +1,14 @@
-import { listDriversByOrg } from '@/lib/fetchers/driverFetchers';
-import  DriverListPage  from '@/features/drivers/DriverListPage';
+import DriverListPage from '@/features/drivers/DriverListPage';
 import { Suspense } from 'react';
-import { notFound } from 'next/navigation';
 
 export default async function DriversPage({ params }: { params: Promise<{ orgId: string }> }) {
   const { orgId } = await params;
-  const result = await listDriversByOrg(orgId);
-  if (!result || !Array.isArray(result.drivers)) return notFound();
 
   return (
     <main className="p-6">
       <h1 className="text-3xl font-bold mb-6">Drivers</h1>
       <Suspense fallback={<div>Loading drivers...</div>}>
-        <DriverListPage orgId={ '' } />
+        <DriverListPage orgId={orgId} />
       </Suspense>
     </main>
   );

--- a/components/drivers/driver-card.tsx
+++ b/components/drivers/driver-card.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Phone, Mail, Calendar, FileText } from "lucide-react"
 import { formatDate } from "@/lib/utils"
+import Link from "next/link"
 
 interface Driver {
   id: string
@@ -21,10 +22,11 @@ interface Driver {
 
 interface DriverCardProps {
   driver: Driver
-  onClick: () => void
+  href?: string
+  onClick?: () => void
 }
 
-export function DriverCard({ driver, onClick }: DriverCardProps) {
+export function DriverCard({ driver, href, onClick }: DriverCardProps) {
   const getStatusColor = (status: string) => {
     switch (status) {
       case "active":
@@ -42,7 +44,7 @@ export function DriverCard({ driver, onClick }: DriverCardProps) {
     return `${firstName.charAt(0)}${lastName.charAt(0)}`
   }
 
-  return (
+  const card = (
     <Card className="cursor-pointer bg-black hover:shadow-md transition-shadow" onClick={onClick}>
       <CardHeader className="pb-2 flex flex-row items-center space-y-0 gap-4">
         <Avatar className="h-12 w-12">
@@ -110,4 +112,6 @@ export function DriverCard({ driver, onClick }: DriverCardProps) {
       </CardFooter>
     </Card>
   )
+
+  return href ? <Link href={href}>{card}</Link> : card
 }

--- a/features/drivers/DriverFormFeature.tsx
+++ b/features/drivers/DriverFormFeature.tsx
@@ -11,9 +11,10 @@ export interface DriverFormFeatureProps {
   mode: "create" | "edit";
   driverId?: string;
   onSuccess?: () => void;
+  orgId?: string;
 }
 
-export function DriverFormFeature({ initialValues, mode, driverId, onSuccess }: DriverFormFeatureProps) {
+export function DriverFormFeature({ initialValues, mode, driverId, orgId, onSuccess }: DriverFormFeatureProps) {
   const [form, setForm] = useState<{
     values: z.infer<typeof driverFormSchema>;
     errors: Record<string, string>;
@@ -75,8 +76,10 @@ export function DriverFormFeature({ initialValues, mode, driverId, onSuccess }: 
       let result;
       if (mode === "edit" && driverId) {
         result = await updateDriverAction(driverId, parsed);
+      } else if (orgId) {
+        result = await createDriverAction(orgId, parsed);
       } else {
-        result = await createDriverAction("", parsed); // TODO: pass tenant/org id
+        throw new Error("Organization ID required to create driver");
       }
       if (result.success) {
         toast({ title: "Driver saved", description: "Driver profile has been updated." });
@@ -91,7 +94,6 @@ export function DriverFormFeature({ initialValues, mode, driverId, onSuccess }: 
   }
 
   function handleUploadDocument() {
-    // TODO: Open document upload dialog/modal for driver
     toast({ title: "Document upload", description: "Document upload not yet implemented." });
   }
 

--- a/features/drivers/DriverListPage.tsx
+++ b/features/drivers/DriverListPage.tsx
@@ -1,6 +1,6 @@
 import { listDriversByOrg } from "@/lib/fetchers/driverFetchers";
 import { DriverCard } from "@/components/drivers/driver-card";
-import { DriverForm } from "@/components/drivers/DriverForm";
+import { DriverFormFeature } from "@/features/drivers/DriverFormFeature";
 import type { DriverFilters } from "@/types/drivers";
 
 interface DriverListPageProps {
@@ -28,6 +28,7 @@ export default async function DriverListPage({
         {drivers.map((driver) => (
           <DriverCard
             key={driver.id}
+            href={`/${orgId}/drivers/${driver.id}`}
             driver={{
               id: driver.id ?? "",
               firstName: driver.firstName ?? "",
@@ -49,34 +50,10 @@ export default async function DriverListPage({
                   ? new Date(driver.hireDate)
                   : new Date(0),
             }}
-            onClick={() => {}}
           />
         ))}
       </div>
-      {/* Pass a form prop as required by DriverFormProps */}
-      <DriverForm
-        form={{
-          values: {
-            firstName: "",
-            lastName: "",
-            email: "",
-            phone: "",
-            hireDate: "",
-            homeTerminal: "",
-            cdlNumber: "",
-            cdlState: "",
-            cdlClass: "A",
-            cdlExpiration: "",
-            medicalCardExpiration: "",
-            tags: [],
-          },
-          errors: {},
-          onChange: () => {},
-          onSubmit: async () => {},
-          submitting: false,
-          mode: "create",
-        }}
-      />
+      <DriverFormFeature mode="create" orgId={orgId} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `href` prop to `<DriverCard>` for easier navigation
- pass org id into `<DriverFormFeature>` and use it when creating drivers
- show driver list with real links and create form
- fix drivers route to pass org id

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68435f936bf08327abce0ba3d2b5fa31