### PR TITLE
Implement HOS status calculation

### DIFF
--- a/lib/utils/hos.ts
+++ b/lib/utils/hos.ts
@@ -1,0 +1,133 @@
+import { HosEntry, HosLog, HosViolation } from '@/types/compliance'
+
+export interface DriverHOSStatus {
+  driverId: string
+  currentStatus: HosEntry['status'] | 'off_duty'
+  availableDriveTime: number
+  availableOnDutyTime: number
+  usedDriveTime: number
+  usedOnDutyTime: number
+  cycleHours: number
+  usedCycleHours: number
+  restartAvailable: boolean
+  violations: HosViolation[]
+  lastLoggedAt: Date | null
+  complianceStatus: 'compliant' | 'violation' | 'pending'
+}
+
+const DRIVE_LIMIT = 11 * 60
+const ON_DUTY_LIMIT = 14 * 60
+const CYCLE_LIMIT = 70 * 60
+
+function minutesBetween(start: Date, end: Date) {
+  return Math.max(0, (end.getTime() - start.getTime()) / 60000)
+}
+
+export function calculateHosStatus(driverId: string, hosLogs: HosLog[]): DriverHOSStatus {
+  if (!hosLogs.length) {
+    return {
+      driverId,
+      currentStatus: 'off_duty',
+      availableDriveTime: DRIVE_LIMIT,
+      availableOnDutyTime: ON_DUTY_LIMIT,
+      usedDriveTime: 0,
+      usedOnDutyTime: 0,
+      cycleHours: CYCLE_LIMIT,
+      usedCycleHours: 0,
+      restartAvailable: false,
+      violations: [],
+      lastLoggedAt: null,
+      complianceStatus: 'pending',
+    }
+  }
+
+  const now = new Date()
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const cycleStart = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000)
+
+  let usedDrive = 0
+  let usedOnDuty = 0
+  let cycleUsed = 0
+  const entries: HosEntry[] = []
+
+  for (const log of hosLogs) {
+    if (Array.isArray(log.logs)) {
+      entries.push(...log.logs)
+    }
+  }
+  entries.sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime())
+
+  for (const entry of entries) {
+    const start = new Date(entry.startTime)
+    const end = new Date(entry.endTime)
+    const mins = minutesBetween(start, end)
+
+    if (start >= startOfToday) {
+      if (entry.status === 'driving') usedDrive += mins
+      if (['driving', 'on_duty'].includes(entry.status)) usedOnDuty += mins
+    }
+    if (start >= cycleStart) {
+      if (['driving', 'on_duty'].includes(entry.status)) cycleUsed += mins
+    }
+  }
+
+  const lastEntry = entries[entries.length - 1]
+  let lastOnDutyEnd: Date | null = null
+  for (const entry of entries) {
+    if (!['off_duty', 'sleeper_berth'].includes(entry.status)) {
+      const end = new Date(entry.endTime)
+      if (!lastOnDutyEnd || end > lastOnDutyEnd) lastOnDutyEnd = end
+    }
+  }
+  const restartAvailable = !lastOnDutyEnd || now.getTime() - lastOnDutyEnd.getTime() >= 34 * 60 * 60 * 1000
+
+  const violations: HosViolation[] = []
+  if (usedDrive >= DRIVE_LIMIT) {
+    violations.push({
+      id: '11',
+      type: '11_hour',
+      description: 'Exceeded 11-hour driving limit',
+      severity: 'major',
+      timestamp: now,
+      resolved: false,
+      status: 'open',
+    })
+  }
+  if (usedOnDuty >= ON_DUTY_LIMIT) {
+    violations.push({
+      id: '14',
+      type: '14_hour',
+      description: 'Exceeded 14-hour on-duty limit',
+      severity: 'major',
+      timestamp: now,
+      resolved: false,
+      status: 'open',
+    })
+  }
+  if (cycleUsed >= CYCLE_LIMIT) {
+    violations.push({
+      id: '70',
+      type: '70_hour',
+      description: 'Exceeded 70-hour 8-day limit',
+      severity: 'major',
+      timestamp: now,
+      resolved: false,
+      status: 'open',
+    })
+  }
+
+  return {
+    driverId,
+    currentStatus: lastEntry ? lastEntry.status : 'off_duty',
+    availableDriveTime: Math.max(DRIVE_LIMIT - usedDrive, 0),
+    availableOnDutyTime: Math.max(ON_DUTY_LIMIT - usedOnDuty, 0),
+    usedDriveTime: usedDrive,
+    usedOnDutyTime: usedOnDuty,
+    cycleHours: CYCLE_LIMIT,
+    usedCycleHours: cycleUsed,
+    restartAvailable,
+    violations,
+    lastLoggedAt: lastEntry ? new Date(lastEntry.endTime) : null,
+    complianceStatus: violations.length > 0 ? 'violation' : 'compliant',
+  }
+}

--- a/tests/hosStatus.test.ts
+++ b/tests/hosStatus.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest'
+import { calculateHosStatus } from '../lib/utils/hos'
+import { HosLog, HosEntry } from '../types/compliance'
+
+function createEntry(status: HosEntry['status'], start: Date, minutes: number): HosEntry {
+  return {
+    id: Math.random().toString(),
+    startTime: start,
+    endTime: new Date(start.getTime() + minutes * 60000),
+    status,
+    location: '',
+    automaticEntry: false,
+    source: 'manual'
+  }
+}
+
+describe('calculateHosStatus', () => {
+  it('handles off-duty only logs', () => {
+    const base = new Date()
+    base.setHours(0,0,0,0)
+    const log: HosLog = {
+      id: '1',
+      tenantId: 't1',
+      driverId: 'd1',
+      date: base,
+      status: 'compliant',
+      logs: [createEntry('off_duty', base, 60)],
+      breaks: [],
+      totalDriveTime: 0,
+      totalOnDutyTime: 0,
+      totalOffDutyTime: 60,
+      sleeperBerthTime: 0,
+      personalConveyanceTime: 0,
+      yardMovesTime: 0,
+      createdAt: base,
+      updatedAt: base
+    }
+    const result = calculateHosStatus('d1', [log])
+    expect(result.currentStatus).toBe('off_duty')
+    expect(result.usedDriveTime).toBe(0)
+    expect(result.complianceStatus).toBe('compliant')
+  })
+
+  it('computes on-duty driving within limits', () => {
+    const base = new Date()
+    base.setHours(0,0,0,0)
+    const entries = [
+      createEntry('on_duty', base, 120),
+      createEntry('driving', new Date(base.getTime() + 120*60000), 300),
+      createEntry('on_duty', new Date(base.getTime() + 420*60000), 60)
+    ]
+    const log: HosLog = {
+      id: '2',
+      tenantId: 't1',
+      driverId: 'd1',
+      date: base,
+      status: 'compliant',
+      logs: entries,
+      breaks: [],
+      totalDriveTime: 300,
+      totalOnDutyTime: 480,
+      totalOffDutyTime: 0,
+      sleeperBerthTime: 0,
+      personalConveyanceTime: 0,
+      yardMovesTime: 0,
+      createdAt: base,
+      updatedAt: base
+    }
+    const res = calculateHosStatus('d1', [log])
+    expect(res.usedDriveTime).toBe(300)
+    expect(res.availableDriveTime).toBe(360)
+    expect(res.currentStatus).toBe('on_duty')
+    expect(res.complianceStatus).toBe('compliant')
+  })
+
+  it('detects driving violation', () => {
+    const base = new Date()
+    base.setHours(0,0,0,0)
+    const log: HosLog = {
+      id: '3',
+      tenantId: 't1',
+      driverId: 'd1',
+      date: base,
+      status: 'violation',
+      logs: [createEntry('driving', base, 720)],
+      breaks: [],
+      totalDriveTime: 720,
+      totalOnDutyTime: 720,
+      totalOffDutyTime: 0,
+      sleeperBerthTime: 0,
+      personalConveyanceTime: 0,
+      yardMovesTime: 0,
+      createdAt: base,
+      updatedAt: base
+    }
+    const res = calculateHosStatus('d1', [log])
+    expect(res.complianceStatus).toBe('violation')
+    expect(res.availableDriveTime).toBe(0)
+  })
+
+  it('flags near violation when less than 30 minutes remain', () => {
+    const base = new Date()
+    base.setHours(0,0,0,0)
+    const log: HosLog = {
+      id: '4',
+      tenantId: 't1',
+      driverId: 'd1',
+      date: base,
+      status: 'compliant',
+      logs: [createEntry('driving', base, 645)],
+      breaks: [],
+      totalDriveTime: 645,
+      totalOnDutyTime: 645,
+      totalOffDutyTime: 0,
+      sleeperBerthTime: 0,
+      personalConveyanceTime: 0,
+      yardMovesTime: 0,
+      createdAt: base,
+      updatedAt: base
+    }
+    const res = calculateHosStatus('d1', [log])
+    expect(res.complianceStatus).toBe('compliant')
+    expect(res.availableDriveTime).toBe(15)
+  })
+})


### PR DESCRIPTION
## Summary
- compute real Hours-of-Service stats in `getDriverHOSStatus`
- add `calculateHosStatus` utility for log evaluation
- cover driver HOS scenarios with vitest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68435f80fb188327b40b633725e8fb40