### PR TITLE
Implement driver CRUD page and form feature

### DIFF
--- a/app/(tenant)/[orgId]/drivers/[userId]/page.tsx
+++ b/app/(tenant)/[orgId]/drivers/[userId]/page.tsx
@@ -101,6 +101,7 @@ export default async function DriverDashboardPage({ params }: { params: Promise<
           <CardContent>
             <Suspense fallback={<LoadingSpinner />}>
               <DriverFormFeature
+                orgId={orgId}
                 initialValues={driverData}
                 mode="edit"
                 driverId={driverData.id}

--- a/app/(tenant)/[orgId]/drivers/page.tsx
+++ b/app/(tenant)/[orgId]/drivers/page.tsx
@@ -1,19 +1,21 @@
-import { listDriversByOrg } from '@/lib/fetchers/driverFetchers';
-import  DriverListPage  from '@/features/drivers/DriverListPage';
-import { Suspense } from 'react';
-import { notFound } from 'next/navigation';
+import DriverListPage from '@/features/drivers/DriverListPage'
+import { Suspense } from 'react'
 
-export default async function DriversPage({ params }: { params: Promise<{ orgId: string }> }) {
-  const { orgId } = await params;
-  const result = await listDriversByOrg(orgId);
-  if (!result || !Array.isArray(result.drivers)) return notFound();
+export default async function DriversPage({
+  params,
+  searchParams,
+}: {
+  params: { orgId: string }
+  searchParams?: Record<string, string | string[] | undefined>
+}) {
+  const { orgId } = params
 
   return (
     <main className="p-6">
       <h1 className="text-3xl font-bold mb-6">Drivers</h1>
       <Suspense fallback={<div>Loading drivers...</div>}>
-        <DriverListPage orgId={ '' } />
+        <DriverListPage orgId={orgId} searchParams={searchParams} />
       </Suspense>
     </main>
-  );
+  )
 }

--- a/features/drivers/DriverFormFeature.tsx
+++ b/features/drivers/DriverFormFeature.tsx
@@ -7,13 +7,14 @@ import { createDriverAction, updateDriverAction } from "@/lib/actions/driverActi
 import { toast } from "@/hooks/use-toast";
 
 export interface DriverFormFeatureProps {
-  initialValues?: z.infer<typeof driverFormSchema>;
-  mode: "create" | "edit";
-  driverId?: string;
-  onSuccess?: () => void;
+  orgId: string
+  initialValues?: z.infer<typeof driverFormSchema>
+  mode: "create" | "edit"
+  driverId?: string
+  onSuccess?: () => void
 }
 
-export function DriverFormFeature({ initialValues, mode, driverId, onSuccess }: DriverFormFeatureProps) {
+export function DriverFormFeature({ orgId, initialValues, mode, driverId, onSuccess }: DriverFormFeatureProps) {
   const [form, setForm] = useState<{
     values: z.infer<typeof driverFormSchema>;
     errors: Record<string, string>;
@@ -76,7 +77,7 @@ export function DriverFormFeature({ initialValues, mode, driverId, onSuccess }: 
       if (mode === "edit" && driverId) {
         result = await updateDriverAction(driverId, parsed);
       } else {
-        result = await createDriverAction("", parsed); // TODO: pass tenant/org id
+        result = await createDriverAction(orgId, parsed);
       }
       if (result.success) {
         toast({ title: "Driver saved", description: "Driver profile has been updated." });
@@ -91,7 +92,6 @@ export function DriverFormFeature({ initialValues, mode, driverId, onSuccess }: 
   }
 
   function handleUploadDocument() {
-    // TODO: Open document upload dialog/modal for driver
     toast({ title: "Document upload", description: "Document upload not yet implemented." });
   }
 

--- a/features/drivers/DriverListPage.tsx
+++ b/features/drivers/DriverListPage.tsx
@@ -1,6 +1,6 @@
 import { listDriversByOrg } from "@/lib/fetchers/driverFetchers";
 import { DriverCard } from "@/components/drivers/driver-card";
-import { DriverForm } from "@/components/drivers/DriverForm";
+import { DriverFormFeature } from "@/features/drivers/DriverFormFeature";
 import type { DriverFilters } from "@/types/drivers";
 
 interface DriverListPageProps {
@@ -49,34 +49,13 @@ export default async function DriverListPage({
                   ? new Date(driver.hireDate)
                   : new Date(0),
             }}
-            onClick={() => {}}
+            onClick={() => {
+              window.location.href = `/${orgId}/drivers/${driver.id}`
+            }}
           />
         ))}
       </div>
-      {/* Pass a form prop as required by DriverFormProps */}
-      <DriverForm
-        form={{
-          values: {
-            firstName: "",
-            lastName: "",
-            email: "",
-            phone: "",
-            hireDate: "",
-            homeTerminal: "",
-            cdlNumber: "",
-            cdlState: "",
-            cdlClass: "A",
-            cdlExpiration: "",
-            medicalCardExpiration: "",
-            tags: [],
-          },
-          errors: {},
-          onChange: () => {},
-          onSubmit: async () => {},
-          submitting: false,
-          mode: "create",
-        }}
-      />
+      <DriverFormFeature orgId={orgId} mode="create" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- wire up driver CRUD flows
- pass orgId to driver form feature
- update driver list page with navigation and creation form
- fix driver page to pass search params
- inject orgId into driver edit forms

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68435f7193dc83278ba2fad1e704cbfc