### PR TITLE
feat: dashboard metrics fetcher and page

### DIFF
--- a/app/(tenant)/[orgId]/dashboard/page.tsx
+++ b/app/(tenant)/[orgId]/dashboard/page.tsx
@@ -1,0 +1,46 @@
+/**
+ * Organization Dashboard Page
+ * Displays fleet overview metrics and widgets.
+ */
+import { Suspense } from 'react';
+
+import FleetOverviewHeader from '@/features/dashboard/fleet-overview-header';
+import KpiGrid from '@/features/dashboard/kpi-grid';
+import QuickActionsWidget from '@/features/dashboard/quick-actions-widget';
+import RecentAlertsWidget from '@/features/dashboard/recent-alerts-widget';
+import TodaysScheduleWidget from '@/features/dashboard/todays-schedule-widget';
+import { DashboardSkeleton } from '@/components/dashboard/dashboard-skeleton';
+
+export default async function DashboardPage({
+  params,
+}: {
+  params: Promise<{ orgId: string }>;
+}) {
+  const { orgId } = await params;
+
+  return (
+    <div className="min-h-screen space-y-6 bg-neutral-900 p-6 pt-8">
+      <Suspense fallback={<DashboardSkeleton />}>
+        <FleetOverviewHeader orgId={orgId} />
+      </Suspense>
+
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <Suspense fallback={<DashboardSkeleton />}>
+          <QuickActionsWidget />
+        </Suspense>
+        <Suspense fallback={<DashboardSkeleton />}>
+          <RecentAlertsWidget orgId={orgId} />
+        </Suspense>
+        <Suspense fallback={<DashboardSkeleton />}>
+          <TodaysScheduleWidget orgId={orgId} />
+        </Suspense>
+      </div>
+
+      <div>
+        <Suspense fallback={<DashboardSkeleton />}>
+          <KpiGrid orgId={orgId} />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/lib/fetchers/dashboardFetchers.ts
+++ b/lib/fetchers/dashboardFetchers.ts
@@ -1,0 +1,38 @@
+import { unstable_cache } from 'next/cache';
+import prisma from '@/lib/database/db';
+
+/**
+ * Fetch basic dashboard metrics with caching.
+ * Metrics include active load, driver, vehicle counts and critical alerts.
+ */
+export const getDashboardMetrics = async (orgId: string) =>
+  unstable_cache(
+    async () => {
+      const [loads, drivers, vehicles, alerts] = await Promise.all([
+        prisma.load.count({
+          where: { organizationId: orgId, status: 'active' },
+        }),
+        prisma.driver.count({
+          where: { organizationId: orgId, status: 'active' },
+        }),
+        prisma.vehicle.count({
+          where: { organizationId: orgId, status: 'active' },
+        }),
+        prisma.complianceAlert.count({
+          where: { organizationId: orgId, severity: 'critical' },
+        }),
+      ]);
+
+      return {
+        loads,
+        drivers,
+        vehicles,
+        alerts,
+      } as const;
+    },
+    ['dashboard-metrics', orgId],
+    {
+      revalidate: 300,
+      tags: [`dashboard-${orgId}`],
+    }
+  )();

--- a/tests/dashboardFetchers.test.ts
+++ b/tests/dashboardFetchers.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock next/cache unstable_cache to simply execute the function
+vi.mock('next/cache', () => ({
+  unstable_cache: (fn: any) => fn,
+}));
+
+// Mock prisma client with sample counts
+vi.mock('@/lib/database/db', () => ({
+  default: {
+    load: { count: vi.fn().mockResolvedValue(3) },
+    driver: { count: vi.fn().mockResolvedValue(4) },
+    vehicle: { count: vi.fn().mockResolvedValue(5) },
+    complianceAlert: { count: vi.fn().mockResolvedValue(2) },
+  },
+}));
+
+import { getDashboardMetrics } from '../lib/fetchers/dashboardFetchers';
+
+describe('getDashboardMetrics', () => {
+  it('returns metrics counts', async () => {
+    const metrics = await getDashboardMetrics('org1');
+    expect(metrics).toEqual({ loads: 3, drivers: 4, vehicles: 5, alerts: 2 });
+  });
+});


### PR DESCRIPTION
## Summary
- add organization dashboard page
- add dashboard metrics fetcher with caching
- test dashboard metrics fetcher

## Testing
- `npm test` *(fails: Playwright suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_68460e9807808327a10b57007c0a570e