### PR TITLE
Add compliance expiration alerts

### DIFF
--- a/tests/getExpiringDocuments.test.ts
+++ b/tests/getExpiringDocuments.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { getExpiringDocuments } from '../lib/fetchers/complianceFetchers';
+import prisma from '../lib/database/db';
+
+vi.mock('../lib/database/db', () => ({
+  __esModule: true,
+  default: {
+    complianceDocument: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: () => Promise.resolve({ userId: 'user1' }),
+}));
+
+describe('getExpiringDocuments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns documents from prisma', async () => {
+    const docs = [{ id: '1', title: 'Test', expirationDate: new Date() }];
+    (prisma.complianceDocument.findMany as any).mockResolvedValue(docs);
+    const res = await getExpiringDocuments('org1', 7);
+    expect(prisma.complianceDocument.findMany).toHaveBeenCalled();
+    expect(res.success).toBe(true);
+    expect(res.data).toEqual(docs);
+  });
+});


### PR DESCRIPTION
## Summary
- fetch expiring compliance documents by organization
- create compliance alerts for documents nearing expiration
- test getExpiringDocuments fetcher

## Testing
- `npx vitest run tests/getExpiringDocuments.test.ts`
- `npx vitest run` *(fails: Playwright tests not supported in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68460eaabfd483279ab7ba954a8d015e