### PR TITLE
config: validate configs with satisfies

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,6 @@
-/** @type {import('next').NextConfig} */
 import path from 'path';
 
-const nextConfig: import('next').NextConfig = {
+const nextConfig = {
   reactStrictMode: true,
   images: {
     domains: [
@@ -46,6 +45,6 @@ const nextConfig: import('next').NextConfig = {
     }
     return config;
   },
-};
+} satisfies import('next').NextConfig;
 
 export default nextConfig;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig, devices } from '@playwright/test';
+import { devices, type PlaywrightTestConfig } from '@playwright/test';
 
-export default defineConfig({
+const config = {
   testDir: './tests',
   timeout: 90 * 1000, // Increased for complex auth flows
   expect: {
@@ -37,4 +37,6 @@ export default defineConfig({
   outputDir: 'test-results/',
   globalSetup: require.resolve('./tests/global-setup'),
   globalTeardown: require.resolve('./tests/global-teardown'),
-});
+} satisfies PlaywrightTestConfig;
+
+export default config;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,7 @@
 import type { Config } from 'tailwindcss';
 import tailwindAnimate from 'tailwindcss-animate';
 
-const config: Config = {
+const config = {
   darkMode: 'class',
   content: [
     './app/**/*.{js,ts,jsx,tsx}',
@@ -26,5 +26,5 @@ const config: Config = {
     },
   },
   plugins: [tailwindAnimate],
-};
-export default config satisfies Config;
+} satisfies Config;
+export default config;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vitest/config';
 import { resolve } from 'path';
+import type { UserConfig } from 'vitest/config';
 
-export default defineConfig({
+const config = {
   test: {
     environment: 'jsdom',
     globals: true,
@@ -11,4 +11,6 @@ export default defineConfig({
       '@': resolve(__dirname, '.'),
     },
   },
-});
+} satisfies UserConfig;
+
+export default config;


### PR DESCRIPTION
## Summary
- use `satisfies` to type-check Next.js config
- validate Tailwind config with `satisfies`
- add `satisfies` validation in Playwright config
- ensure Vitest config uses `satisfies`

## Testing
- `npm test` *(fails: Playwright suite errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_68463a0d8db48327a20b6c82026bb08c