### PR TITLE
Add server directives to fetchers

### DIFF
--- a/lib/fetchers/dashboardFetchers.ts
+++ b/lib/fetchers/dashboardFetchers.ts
@@ -1,3 +1,5 @@
+'use server';
+
 import { unstable_cache } from 'next/cache';
 import prisma from '@/lib/database/db';
 

--- a/lib/fetchers/driverFetchers.ts
+++ b/lib/fetchers/driverFetchers.ts
@@ -1,3 +1,5 @@
+'use server';
+
 import { auth } from '@clerk/nextjs/server';
 
 import prisma from '@/lib/database/db';

--- a/lib/fetchers/onboardingFetchers.ts
+++ b/lib/fetchers/onboardingFetchers.ts
@@ -1,3 +1,5 @@
+'use server';
+
 import { db, handleDatabaseError } from '@/lib/database/db';
 import type { OnboardingStatus } from '@/types/onboarding';
 


### PR DESCRIPTION
## Summary
- mark dashboard, driver, and onboarding fetchers as server modules

## Testing
- `npm test` *(fails: vitest and playwright tests)*

------
https://chatgpt.com/codex/tasks/task_e_68463a19f7ec8327805319e9ece2225a