### PR TITLE
Add validation and auth to global search action

### DIFF
--- a/lib/actions/searchActions.ts
+++ b/lib/actions/searchActions.ts
@@ -2,11 +2,28 @@
 
 import type { GlobalSearchResultItem } from '@/types/search';
 import { globalSearch } from '@/lib/fetchers/searchFetchers';
+import { z } from 'zod';
+import { getCurrentUser } from '@/lib/auth/auth';
+import { handleError } from '@/lib/errors/handleError';
 
-export async function globalSearchAction(data: {
-  orgId: string;
-  query: string;
-}): Promise<GlobalSearchResultItem[]> {
-  const { orgId, query } = data;
-  return globalSearch(orgId, query);
+const searchSchema = z.object({
+  orgId: z.string().min(1),
+  query: z.string().min(1),
+});
+
+export async function globalSearchAction(
+  data: z.infer<typeof searchSchema>
+): Promise<GlobalSearchResultItem[]> {
+  try {
+    const { orgId, query } = searchSchema.parse(data);
+    const user = await getCurrentUser();
+    if (!user?.userId || user.organizationId !== orgId) {
+      throw new Error('Unauthorized');
+    }
+
+    return await globalSearch(orgId, query);
+  } catch (error) {
+    handleError(error, 'Global Search Action');
+    return [];
+  }
 }


### PR DESCRIPTION
## Summary
- validate and authorize `globalSearchAction`
- handle errors using `handleError`

## Testing
- `npm test --silent` *(fails: No "prisma" export is defined and Playwright test.describe issues)*

------
https://chatgpt.com/codex/tasks/task_e_68463a4891048327a59f0cf05ddaa71d