### PR TITLE
refactor ifta components to respect server fetch rules

### DIFF
--- a/components/ifta/TaxRateManager.tsx
+++ b/components/ifta/TaxRateManager.tsx
@@ -1,69 +1,7 @@
-'use client';
-
-import { useEffect, useState } from 'react';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { getJurisdictionRates } from '@/lib/fetchers/iftaFetchers';
+import { TaxRateManagerClient } from './TaxRateManagerClient';
 
-interface RateRow {
-  jurisdiction: string;
-  rate: number;
-}
-
-export function TaxRateManager() {
-  const [rates, setRates] = useState<RateRow[]>([]);
-  const [edited, setEdited] = useState<Record<string, number>>({});
-
-  useEffect(() => {
-    const loadRates = async () => {
-      const data = await getJurisdictionRates();
-      setRates(
-        Object.entries(data).map(([j, r]) => ({ jurisdiction: j, rate: r }))
-      );
-    };
-    loadRates();
-  }, []);
-
-  const handleChange = (j: string, val: string) => {
-    setEdited(prev => ({ ...prev, [j]: parseFloat(val) || 0 }));
-  };
-
-  const applyChanges = () => {
-    setRates(rates.map(r => ({
-      ...r,
-      rate: edited[r.jurisdiction] ?? r.rate,
-    })));
-    setEdited({});
-  };
-
-  return (
-    <div className="space-y-4">
-      <h3 className="text-xl font-semibold">Jurisdiction Tax Rates</h3>
-      <table className="w-full text-sm">
-        <thead>
-          <tr className="border-b">
-            <th className="p-2 text-left">State</th>
-            <th className="p-2 text-right">Rate</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rates.map(row => (
-            <tr key={row.jurisdiction} className="border-b">
-              <td className="p-2">{row.jurisdiction}</td>
-              <td className="p-2 text-right">
-                <Input
-                  className="w-24 text-right"
-                  defaultValue={row.rate}
-                  onChange={e => handleChange(row.jurisdiction, e.target.value)}
-                />
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-      <Button size="sm" onClick={applyChanges}>
-        Save Changes
-      </Button>
-    </div>
-  );
+export async function TaxRateManager() {
+  const rates = await getJurisdictionRates();
+  return <TaxRateManagerClient initialRates={rates} />;
 }

--- a/components/ifta/TaxRateManagerClient.tsx
+++ b/components/ifta/TaxRateManagerClient.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+interface RateRow {
+  jurisdiction: string;
+  rate: number;
+}
+
+interface TaxRateManagerClientProps {
+  initialRates: Record<string, number>;
+}
+
+export function TaxRateManagerClient({ initialRates }: TaxRateManagerClientProps) {
+  const [rates, setRates] = useState<RateRow[]>(
+    Object.entries(initialRates).map(([j, r]) => ({ jurisdiction: j, rate: r }))
+  );
+  const [edited, setEdited] = useState<Record<string, number>>({});
+
+  const handleChange = (j: string, val: string) => {
+    setEdited(prev => ({ ...prev, [j]: parseFloat(val) || 0 }));
+  };
+
+  const applyChanges = () => {
+    setRates(rates.map(r => ({
+      ...r,
+      rate: edited[r.jurisdiction] ?? r.rate,
+    })));
+    setEdited({});
+  };
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-xl font-semibold">Jurisdiction Tax Rates</h3>
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b">
+            <th className="p-2 text-left">State</th>
+            <th className="p-2 text-right">Rate</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rates.map(row => (
+            <tr key={row.jurisdiction} className="border-b">
+              <td className="p-2">{row.jurisdiction}</td>
+              <td className="p-2 text-right">
+                <Input
+                  className="w-24 text-right"
+                  defaultValue={row.rate}
+                  onChange={e => handleChange(row.jurisdiction, e.target.value)}
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <Button size="sm" onClick={applyChanges}>
+        Save Changes
+      </Button>
+    </div>
+  );
+}

--- a/components/ifta/ifta-dashboard.tsx
+++ b/components/ifta/ifta-dashboard.tsx
@@ -27,11 +27,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Progress } from '@/components/ui/progress';
-import {
-  getIftaDataForPeriod,
-  getIftaTripData,
-  getIftaFuelPurchases,
-} from '@/lib/fetchers/iftaFetchers';
+import { fetchIftaDataAction } from '@/lib/actions/iftaActions';
 
 import { IftaReportTable } from './ifta-report-table';
 import { IftaTripTable } from './ifta-trip-table';
@@ -64,7 +60,7 @@ export function IftaDashboard() {
       try {
         setLoading(true);
         const [quarterPart, yearPart] = quarter.split('-');
-        const data = await getIftaDataForPeriod(orgId, quarterPart, yearPart);
+        const data = await fetchIftaDataAction(orgId, quarterPart, yearPart);
         // Ensure data matches IftaData shape
         if (
           data &&

--- a/lib/actions/iftaActions.ts
+++ b/lib/actions/iftaActions.ts
@@ -288,3 +288,13 @@ export async function generateCustomIFTAReport(
     };
   }
 }
+
+export async function fetchIftaDataAction(orgId: string, quarter: string, year: string) {
+  try {
+    await checkIftaPermissions(orgId);
+    return await getIftaDataForPeriod(orgId, quarter, year);
+  } catch (error) {
+    console.error('Error fetching IFTA data:', error);
+    throw new Error('Failed to fetch IFTA data');
+  }
+}


### PR DESCRIPTION
## Summary
- create `TaxRateManagerClient` to keep interactivity
- wrap `TaxRateManager` in a server component to load rates
- use new `fetchIftaDataAction` in `IftaDashboard`

## Testing
- `npm test` *(fails: No "prisma" export is defined & Playwright configuration errors)*

------
https://chatgpt.com/codex/tasks/task_e_68463906c8f8832783d46b36776c68af