### PR TITLE
Fix toast listener effect

### DIFF
--- a/components/ui/use-toast.ts
+++ b/components/ui/use-toast.ts
@@ -182,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,

--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1);
       }
     };
-  }, [state]);
+  }, []);
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- only register toast state listener once and cleanup on unmount

## Testing
- `npm test` *(fails: vitest tests rely on missing Playwright environment)*

------
https://chatgpt.com/codex/tasks/task_e_68463ad9ed008327ba046901e7b4c101