### PR TITLE
Implement Clerk integration for user actions

### DIFF
--- a/lib/actions/userActions.ts
+++ b/lib/actions/userActions.ts
@@ -1,12 +1,53 @@
 'use server';
 
+import { auth, clerkClient } from '@clerk/nextjs/server';
+import { z } from 'zod';
+
+import { SystemRoles } from '@/types/abac';
+import { handleError } from '@/lib/errors/handleError';
+
+const roleEnum = z.enum(
+  Object.values(SystemRoles) as [string, ...string[]]
+);
+
+const inviteUserSchema = z.object({
+  orgId: z.string().min(1),
+  email: z.string().email(),
+  role: roleEnum,
+});
+
+const updateRoleSchema = z.object({
+  orgId: z.string().min(1),
+  userId: z.string().min(1),
+  newRole: roleEnum,
+});
+
 export async function inviteUserAction(
   orgId: string,
   email: string,
   role: string
 ) {
-  // ...invite user via Clerk...
-  return { success: true };
+  try {
+    const { userId, orgId: sessionOrgId } = await auth();
+    if (!userId || sessionOrgId !== orgId) {
+      throw new Error('Unauthorized');
+    }
+
+    const validated = inviteUserSchema.parse({ orgId, email, role });
+
+    const client = await clerkClient();
+    await client.organizations.createOrganizationInvitation({
+      organizationId: validated.orgId,
+      inviterUserId: userId,
+      emailAddress: validated.email,
+      role: validated.role,
+      redirectUrl: `${process.env.NEXT_PUBLIC_APP_URL}/accept-invite`,
+    });
+
+    return { success: true };
+  } catch (error) {
+    return handleError(error, 'Invite User Action');
+  }
 }
 
 export async function updateUserRoleAction(
@@ -14,6 +55,27 @@ export async function updateUserRoleAction(
   userId: string,
   newRole: string
 ) {
-  // ...update role in Clerk and DB...
-  return { success: true };
+  try {
+    const { userId: sessionUserId, orgId: sessionOrgId } = await auth();
+    if (!sessionUserId || sessionOrgId !== orgId) {
+      throw new Error('Unauthorized');
+    }
+
+    const validated = updateRoleSchema.parse({ orgId, userId, newRole });
+
+    const client = await clerkClient();
+    await client.organizations.updateOrganizationMembership({
+      organizationId: validated.orgId,
+      userId: validated.userId,
+      role: validated.newRole,
+    });
+
+    await client.users.updateUser(validated.userId, {
+      publicMetadata: { role: validated.newRole },
+    });
+
+    return { success: true };
+  } catch (error) {
+    return handleError(error, 'Update User Role');
+  }
 }


### PR DESCRIPTION
## Summary
- add Clerk integration for inviting and updating user roles
- validate user action inputs with Zod
- ensure errors return consistent `{ success, error }`

## Testing
- `npm test` *(fails: Playwright/Vitest errors)*

------
https://chatgpt.com/codex/tasks/task_e_68463a4707588327b5de5106fe3cb63f