### PR TITLE
Remove client directives from error pages

### DIFF
--- a/app/(funnel)/error.tsx
+++ b/app/(funnel)/error.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import React from 'react';
 import Image from 'next/image';
 

--- a/app/(tenant)/[orgId]/error.tsx
+++ b/app/(tenant)/[orgId]/error.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import React from 'react';
 import Image from 'next/image';
 


### PR DESCRIPTION
## Summary
- drop `'use client';` from funnel and tenant error pages

## Testing
- `npm test` *(fails: Vitest and Playwright tests)*

------
https://chatgpt.com/codex/tasks/task_e_68463a1b3a9c83279474c037c79ac28d