### PR TITLE
Use server action to fetch load details

### DIFF
--- a/lib/actions/dispatchActions.ts
+++ b/lib/actions/dispatchActions.ts
@@ -447,3 +447,29 @@ export async function assignDriverAction(input: LoadAssignmentInput) {
     };
   }
 }
+
+// Fetch a single load by id with relations
+export async function getLoadById(orgId: string, loadId: string) {
+  try {
+    await checkUserPermissions(orgId, ['dispatch:manage', 'loads:update']);
+    const load = await prisma.load.findFirst({
+      where: { id: loadId, organizationId: orgId },
+      include: {
+        driver: true,
+        vehicle: true,
+        trailer: true,
+        statusEvents: { orderBy: { timestamp: 'desc' } },
+      },
+    });
+    if (!load) {
+      return { success: false, error: 'Load not found' };
+    }
+    return { success: true, data: load };
+  } catch (error) {
+    console.error('Error fetching load by id:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to fetch load',
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add `getLoadById` server action in `dispatchActions`
- fetch load data on the server in edit page

## Testing
- `npm test --silent` *(fails: getExpiringDocuments, utils-edge)*

------
https://chatgpt.com/codex/tasks/task_e_68463ac9655c83279a03e27cb78a4ded