### PR TITLE
refactor: centralize role constants

### DIFF
--- a/app/(auth)/accept-invitation/page.tsx
+++ b/app/(auth)/accept-invitation/page.tsx
@@ -91,7 +91,7 @@ export default function AcceptInvitationPage() {
       case SystemRoles.DISPATCHER:
         return `/${orgId}/dispatcher/${userId}`;
       case SystemRoles.DRIVER:
-        return `/${orgId}/driver/${userId}`;
+        return `/${orgId}/drivers/${userId}`;
       case SystemRoles.COMPLIANCE_OFFICER:
         return `/${orgId}/compliance/${userId}`;
       case SystemRoles.ACCOUNTANT:

--- a/app/(auth)/onboarding/page.tsx
+++ b/app/(auth)/onboarding/page.tsx
@@ -16,6 +16,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { toast } from '@/hooks/use-toast';
 import type { OnboardingData } from '@/types/auth';
+import { SystemRoles } from '@/types/abac';
 import { setClerkMetadata } from '@/lib/actions/onboardingActions';
 
 // Utility to generate a base slug from company name
@@ -128,7 +129,7 @@ export default function OnboardingPage() {
         state: formData.state.trim(),
         zip: formData.zip.trim(),
         phone: formData.phone.trim(),
-        role: 'admin', // Default to admin for onboarding
+        role: SystemRoles.ADMIN, // Default to admin for onboarding
         onboardingComplete: true,
       };
 

--- a/components/auth/context.tsx
+++ b/components/auth/context.tsx
@@ -29,6 +29,7 @@ import {
   Permission,
   ROLE_PERMISSIONS,
 } from '@/types/auth';
+import { SystemRoles } from '@/types/abac';
 import { authCache } from '@/lib/cache/auth-cache';
 
 // Create the auth context
@@ -70,7 +71,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       userMetadata: ClerkUserMetadata,
       orgMetadata: ClerkOrganizationMetadata
     ): UserContext => {
-      const role: UserRole = userMetadata?.role || 'viewer';
+      const role: UserRole = userMetadata?.role || SystemRoles.VIEWER;
       const permissions: Permission[] =
         userMetadata?.permissions || ROLE_PERMISSIONS[role] || [];
 
@@ -316,7 +317,7 @@ export function useAllPermissions(permissions: Permission[]): boolean {
  * Hook to check if user is admin
  */
 export function useIsAdmin(): boolean {
-  return useRole('admin');
+  return useRole(SystemRoles.ADMIN);
 }
 
 /**

--- a/components/settings/settings-dashboard.tsx
+++ b/components/settings/settings-dashboard.tsx
@@ -19,6 +19,7 @@ import { IntegrationSettings } from './integration-settings';
 import { BillingSettingsForm } from './billing-settings';
 import { Button } from '../ui/button';
 import { useUserContext } from '@/components/auth/context';
+import { SystemRoles, type SystemRole } from '@/types/abac';
 
 // Loading component for Settings page
 function SettingsLoading() {
@@ -243,14 +244,20 @@ function SupportSettings() {
 // Main Settings Dashboard
 export function SettingsDashboard() {
   const user = useUserContext();
-  const role = user?.role ?? 'viewer';
-  const tabsByRole: Record<string, string[]> = {
-    admin: ['user', 'company', 'notifications', 'integrations', 'billing'],
-    dispatcher: ['user', 'company', 'notifications'],
-    driver: ['user', 'notifications'],
-    compliance_officer: ['company', 'notifications'],
-    accountant: ['company', 'billing'],
-    viewer: ['user'],
+  const role = user?.role ?? SystemRoles.VIEWER;
+  const tabsByRole: Record<SystemRole, string[]> = {
+    [SystemRoles.ADMIN]: [
+      'user',
+      'company',
+      'notifications',
+      'integrations',
+      'billing',
+    ],
+    [SystemRoles.DISPATCHER]: ['user', 'company', 'notifications'],
+    [SystemRoles.DRIVER]: ['user', 'notifications'],
+    [SystemRoles.COMPLIANCE_OFFICER]: ['company', 'notifications'],
+    [SystemRoles.ACCOUNTANT]: ['company', 'billing'],
+    [SystemRoles.VIEWER]: ['user'],
   };
   const allowedTabs = tabsByRole[role] || ['user'];
 

--- a/components/shared/MainNav.tsx
+++ b/components/shared/MainNav.tsx
@@ -16,6 +16,7 @@ import { useClerk } from '@clerk/nextjs';
 
 import { cn } from '@/lib/utils/utils';
 import { useUserContext } from '@/components/auth/context';
+import { SystemRoles, type SystemRole } from '@/types/abac';
 
 // MainNavProps interface: defines props for MainNav component
 interface MainNavProps {
@@ -36,7 +37,7 @@ export function MainNav({
 }: MainNavProps) {
   const { signOut } = useClerk();
   const user = useUserContext();
-  const userRole = user?.role || 'viewer';
+  const userRole: SystemRole = user?.role || SystemRoles.VIEWER;
 
   // navLinks: array of navigation link objects for the sidebar
   const navLinks = [
@@ -45,49 +46,66 @@ export function MainNav({
       href: `/${orgId}/dashboard/${userId}`,
       label: 'Dashboard',
       icon: <Home className="h-5 w-5" />,
-      roles: ['admin', 'dispatcher', 'driver', 'compliance_officer', 'accountant', 'viewer'],
+      roles: [
+        SystemRoles.ADMIN,
+        SystemRoles.DISPATCHER,
+        SystemRoles.DRIVER,
+        SystemRoles.COMPLIANCE_OFFICER,
+        SystemRoles.ACCOUNTANT,
+        SystemRoles.VIEWER,
+      ],
     },
     {
       key: 'dispatch',
       href: `/${orgId}/dispatch/${userId}`,
       label: 'Dispatch',
       icon: <ClipboardList className="h-5 w-5" />,
-      roles: ['admin', 'dispatcher'],
+      roles: [SystemRoles.ADMIN, SystemRoles.DISPATCHER],
     },
     {
       key: 'drivers',
       href: `/${orgId}/drivers/${userId}`,
       label: 'Drivers',
       icon: <Users className="h-5 w-5" />,
-      roles: ['admin', 'dispatcher', 'compliance_officer', 'accountant'],
+      roles: [
+        SystemRoles.ADMIN,
+        SystemRoles.DISPATCHER,
+        SystemRoles.COMPLIANCE_OFFICER,
+        SystemRoles.ACCOUNTANT,
+      ],
     },
     {
       key: 'vehicles',
       href: `/${orgId}/vehicles`,
       label: 'Vehicles',
       icon: <Truck className="h-5 w-5" />,
-      roles: ['admin', 'dispatcher', 'compliance_officer', 'accountant'],
+      roles: [
+        SystemRoles.ADMIN,
+        SystemRoles.DISPATCHER,
+        SystemRoles.COMPLIANCE_OFFICER,
+        SystemRoles.ACCOUNTANT,
+      ],
     },
     {
       key: 'compliance',
       href: `/${orgId}/compliance/${userId}`,
       label: 'Compliance',
       icon: <FileText className="h-5 w-5" />,
-      roles: ['admin', 'compliance_officer'],
+      roles: [SystemRoles.ADMIN, SystemRoles.COMPLIANCE_OFFICER],
     },
     {
       key: 'ifta',
       href: `/${orgId}/ifta`,
       label: 'IFTA',
       icon: <Activity className="h-5 w-5" />,
-      roles: ['admin', 'accountant'],
+      roles: [SystemRoles.ADMIN, SystemRoles.ACCOUNTANT],
     },
     {
       key: 'analytics',
       href: `/${orgId}/analytics`,
       label: 'Analytics',
       icon: <BarChart2 className="h-5 w-5" />,
-      roles: ['admin', 'accountant'],
+      roles: [SystemRoles.ADMIN, SystemRoles.ACCOUNTANT],
     },
     {
       key: 'admin',
@@ -100,7 +118,7 @@ export function MainNav({
       href: `/${orgId}/settings`,
       label: 'Settings',
       icon: <Settings className="h-5 w-5" />,
-      roles: ['admin'],
+      roles: [SystemRoles.ADMIN],
     },
     {
       key: 'signout',

--- a/lib/actions/onboardingActions.ts
+++ b/lib/actions/onboardingActions.ts
@@ -59,7 +59,7 @@ export async function submitOnboardingStepAction(
 
       case 'company':
         { const companyData = data as CompanySetupData;
-        if (dbUser.role === 'admin' || dbUser.role === 'manager') {
+        if (dbUser.role === SystemRoles.ADMIN) {
           if (dbUser.organizationId) {
             // Ensure organizationId is not null
             await db.organization.update({


### PR DESCRIPTION
## Summary
- rely on SystemRoles constants instead of string literals
- fix driver redirect path
- update onboarding action role check

## Testing
- `npm test` *(fails: vitest and playwright errors)*

------
https://chatgpt.com/codex/tasks/task_e_684639f6d60c8327929a127bd7e90846