### PR TITLE
fix: Neon database connection and Prisma organization queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@clerk/nextjs": "^6.20.0",
         "@hookform/resolvers": "^5.0.1",
         "@neondatabase/serverless": "^1.0.0",
-        "@prisma/adapter-neon": "^6.8.2",
+        "@prisma/adapter-neon": "6.8.2",
         "@prisma/client": "^6.8.2",
         "@radix-ui/react-accordion": "1.2.2",
         "@radix-ui/react-alert-dialog": "1.1.4",
@@ -1670,12 +1670,12 @@
       }
     },
     "node_modules/@prisma/adapter-neon": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@prisma/adapter-neon/-/adapter-neon-6.9.0.tgz",
-      "integrity": "sha512-IieUWFTXB4PliGenc0MuShyLlAfO8rpWQr9T3oim/uztnvIFcz9PSia83kdrCfaNKre+MJH3GJd3bI/RvGrWWg==",
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/@prisma/adapter-neon/-/adapter-neon-6.8.2.tgz",
+      "integrity": "sha512-wBAAoWv7CZhgY/kLGBF+NvQejqYP/GGKg/ms8gwzP6VgsoROBxY0YUJ3Y25pAFdezUj++xmn7vvAEewIproVGA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/driver-adapter-utils": "6.9.0",
+        "@prisma/driver-adapter-utils": "6.8.2",
         "postgres-array": "3.0.4"
       },
       "peerDependencies": {
@@ -1718,16 +1718,23 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.9.0.tgz",
       "integrity": "sha512-bFeur/qi/Q+Mqk4JdQ3R38upSYPebv5aOyD1RKywVD+rAMLtRkmTFn28ZuTtVOnZHEdtxnNOCH+bPIeSGz1+Fg==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/driver-adapter-utils": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@prisma/driver-adapter-utils/-/driver-adapter-utils-6.9.0.tgz",
-      "integrity": "sha512-HtugVGw5y50drVTboKubHJeOmoUQfDZa8vJBhzgR+iZ8KfUsJuTIU20rNd7Hi/S+JdLJGJXIxzbXiQABMNArjw==",
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/@prisma/driver-adapter-utils/-/driver-adapter-utils-6.8.2.tgz",
+      "integrity": "sha512-5+CzN/41gBsRmA3ekbVy1TXnSImSPBtMlxWAttVH6tg94bv4zGGRmyk5tUCdT83nl0hG1Sq2oMXR7ml6aqILvw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.9.0"
+        "@prisma/debug": "6.8.2"
       }
+    },
+    "node_modules/@prisma/driver-adapter-utils/node_modules/@prisma/debug": {
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.8.2.tgz",
+      "integrity": "sha512-4muBSSUwJJ9BYth5N8tqts8JtiLT8QI/RSAzEogwEfpbYGFo9mYsInsVo8dqXdPO2+Rm5OG5q0qWDDE3nyUbVg==",
+      "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
       "version": "6.9.0",
@@ -3937,6 +3944,60 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.4.3",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.0.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.4.3",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.10",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.9.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.9.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.0",
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.10",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "test:watch": "vitest --watch",
     "test:coverage": "vitest --coverage",
     "type-check": "tsc --noEmit",
-    "db:push": "prisma db push",
-    "db:seed": "tsx prisma/seed.ts",
-    "db:reset": "prisma migrate reset --force",
-    "db:generate": "prisma generate",
+    "db:push": "PRISMA_DATABASE_URL=$DIRECT_URL prisma db push",
+    "db:seed": "PRISMA_DATABASE_URL=$DIRECT_URL tsx prisma/seed.ts",
+    "db:reset": "PRISMA_DATABASE_URL=$DIRECT_URL prisma migrate reset --force",
+    "db:generate": "PRISMA_DATABASE_URL=$DIRECT_URL prisma generate",
     "db:studio": "prisma studio"
   },
   "dependencies": {
@@ -27,7 +27,7 @@
     "@clerk/nextjs": "^6.20.0",
     "@hookform/resolvers": "^5.0.1",
     "@neondatabase/serverless": "^1.0.0",
-    "@prisma/adapter-neon": "^6.8.2",
+    "@prisma/adapter-neon": "6.8.2",
     "@prisma/client": "^6.8.2",
     "@radix-ui/react-accordion": "1.2.2",
     "@radix-ui/react-alert-dialog": "1.1.4",

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,6 +1,9 @@
 import { PrismaClient } from '@prisma/client';
+import { PrismaNeon } from '@prisma/adapter-neon';
 
-const prisma = new PrismaClient();
+const connectionString = process.env.DIRECT_URL || process.env.DATABASE_URL!;
+const adapter = new PrismaNeon({ connectionString });
+const prisma = new PrismaClient({ adapter });
 
 async function main() {
   // Find admin user and driver user by email (adjust emails as needed)


### PR DESCRIPTION
## Summary
- wire PrismaNeon adapter with connection options
- guard slow-query middleware from recursive logging
- fix organization lookups by clerkId
- use Neon adapter for seed script
- run prisma CLI with DIRECT_URL and pin adapter version

Closes #111

## Testing
- `npm test` *(fails: No test files found)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_684b951f4f048327acfd6902e4515b56