### PR TITLE
feat: add regulatory compliance audit engine

### DIFF
--- a/components/compliance/compliance-dashboard.tsx
+++ b/components/compliance/compliance-dashboard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useTransition } from 'react';
 import {
   AlertTriangle,
   CheckCircle,
@@ -24,6 +24,7 @@ import { Progress } from '@/components/ui/progress';
 import { DriverComplianceTable } from './driver-compliance-table';
 import { VehicleComplianceTable } from './vehicle-compliance-table';
 import { ComplianceDocuments } from './compliance-documents';
+import { runRegulatoryAudit } from '@/lib/actions/regulatoryAuditActions';
 
 interface ComplianceDashboardProps {
   orgId: string;
@@ -31,6 +32,16 @@ interface ComplianceDashboardProps {
 
 export function ComplianceDashboard({ orgId }: ComplianceDashboardProps) {
   const [activeTab, setActiveTab] = useState('overview');
+  const [isPending, startTransition] = useTransition();
+
+  const handleAudit = () => {
+    const now = new Date();
+    const quarter = `Q${Math.floor(now.getMonth() / 3) + 1}`;
+    const year = now.getFullYear();
+    startTransition(async () => {
+      await runRegulatoryAudit(orgId, quarter, year);
+    });
+  };
 
   return (
     <div className="space-y-6">
@@ -44,7 +55,9 @@ export function ComplianceDashboard({ orgId }: ComplianceDashboardProps) {
         </div>
         <div className="flex items-center gap-2">
           <Button variant="outline">Export Report</Button>
-          <Button>Run Compliance Check</Button>
+          <Button onClick={handleAudit} disabled={isPending}>
+            {isPending ? 'Running...' : 'Run Compliance Check'}
+          </Button>
         </div>
       </div>
 

--- a/lib/actions/regulatoryAuditActions.ts
+++ b/lib/actions/regulatoryAuditActions.ts
@@ -1,0 +1,28 @@
+'use server';
+
+import db from '@/lib/database/db';
+import { Prisma } from '@prisma/client';
+import { logAuditEvent } from './auditActions';
+import { getRegulatoryComplianceSummary } from '../compliance/regulatoryEngine';
+
+export async function runRegulatoryAudit(
+  organizationId: string,
+  quarter: string,
+  year: number
+) {
+  const summary = await getRegulatoryComplianceSummary(organizationId, quarter, year);
+
+  const record = await db.regulatoryAudit.create({
+    data: {
+      organizationId,
+      quarter,
+      year,
+      summary: summary as unknown as Prisma.InputJsonValue,
+      createdAt: new Date(),
+    },
+  });
+
+  await logAuditEvent('run_regulatory_audit', 'regulatory_audit', record.id, summary);
+
+  return { success: true, data: record };
+}

--- a/lib/compliance/regulatoryEngine.ts
+++ b/lib/compliance/regulatoryEngine.ts
@@ -1,0 +1,39 @@
+'use server';
+
+import { calculateQuarterlyTaxes } from '@/lib/fetchers/iftaFetchers';
+import { getHOSViolations, getComplianceAlerts } from '@/lib/fetchers/complianceFetchers';
+import { getAuditLogs } from '@/lib/actions/auditLogActions';
+
+export interface RegulatorySummary {
+  quarter: string;
+  year: number;
+  ifta: Awaited<ReturnType<typeof calculateQuarterlyTaxes>>;
+  hosViolations: number;
+  safetyEvents: number;
+  auditEvents: number;
+}
+
+/**
+ * Aggregate IFTA, HOS, and safety compliance metrics
+ */
+export async function getRegulatoryComplianceSummary(
+  organizationId: string,
+  quarter: string,
+  year: number
+): Promise<RegulatorySummary> {
+  const ifta = await calculateQuarterlyTaxes(organizationId, quarter, year.toString());
+  const hos = await getHOSViolations(organizationId, { limit: 1 });
+  const hosCount = (hos as any).success ? (hos as any).data.pagination.total : 0;
+  const safety = await getComplianceAlerts(organizationId, { type: 'safety_event', limit: 1 });
+  const safetyCount = (safety as any).success ? (safety as any).data.pagination.total : 0;
+  const audits = await getAuditLogs(organizationId);
+
+  return {
+    quarter,
+    year,
+    ifta,
+    hosViolations: hosCount,
+    safetyEvents: safetyCount,
+    auditEvents: audits.length,
+  };
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,6 +50,7 @@ model Organization {
   iftaTaxCalculations    IftaTaxCalculation[]
   iftaAuditLogs          IftaAuditLog[]
   iftaPDFGenerationLogs  IftaPDFGenerationLog[]
+  regulatoryAudits       RegulatoryAudit[]
 
   @@index([slug])
   @@map("organizations")
@@ -756,4 +757,18 @@ model UserPreferences {
   updatedAt           DateTime  @updatedAt
 
   @@index([userId])
+}
+
+model RegulatoryAudit {
+  id             String       @id @default(uuid())
+  organizationId String       @map("organization_id")
+  quarter        String
+  year           Int
+  summary        Json
+  createdAt      DateTime     @default(now()) @map("created_at")
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  @@index([organizationId])
+  @@index([quarter, year])
+  @@map("regulatory_audits")
 }


### PR DESCRIPTION
## Summary
- add regulatory compliance engine for IFTA, HOS, and safety metrics
- expose server action to run audits and log results
- wire up compliance dashboard button to trigger audit
- extend schema with `RegulatoryAudit` model

Closes #120

## Checklist
- [x] Passes CI
- [ ] Updates documentation
- [x] Notifies project board/milestone

------
https://chatgpt.com/codex/tasks/task_e_684b97303e3483278fad380600e0586d