### PR TITLE
fix: server-side data fetching patterns and hydration issues

### DIFF
--- a/app/(tenant)/[orgId]/layout.tsx
+++ b/app/(tenant)/[orgId]/layout.tsx
@@ -7,17 +7,18 @@ import { TopNavBar } from '@/components/shared/TopNavBar';
 import { MainNav } from '@/components/shared/MainNav';
 import { MobileNav } from '@/components/shared/MobileNav';
 import { useUserContext } from '@/components/auth/context';
+import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
 
 interface TenantLayoutProps {
   children: React.ReactNode;
-  params: Promise<{ orgId: string }>;
+  params: { orgId: string };
 }
 /**
  * Client Component for Tenant Layout
  * Receives orgId from server component and uses auth context for userId
  */
-export async function TenantLayout({ children, params }: TenantLayoutProps) {
-  const { orgId } = await params;
+export function TenantLayout({ children, params }: TenantLayoutProps) {
+  const { orgId } = params;
   const isMobile = useIsMobile();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const userContext = useUserContext();
@@ -39,11 +40,16 @@ export async function TenantLayout({ children, params }: TenantLayoutProps) {
     return (
       <div className="min-h-screen bg-gray-900">
         <header className="fixed top-0 left-0 z-50 w-full border-b border-gray-700 bg-gray-800 shadow-lg">
-          <TopNavBar user={user || {name: 'Guest', email: 'guest@example.com', profileImage: ''}} organization={organization || {name: 'Guest Organization'}}/>
+          <TopNavBar
+            user={user || { name: 'Guest', email: 'guest@example.com', profileImage: '' }}
+            organization={organization || { name: 'Guest Organization' }}
+          />
         </header>
         <div className="pt-[64px]">
           <MobileNav />
-          <main className="mx-auto w-full max-w-3xl p-4 md:p-8">{children}</main>
+          <main className="mx-auto w-full max-w-3xl p-4 md:p-8">
+            <ErrorBoundary>{children}</ErrorBoundary>
+          </main>
         </div>
       </div>
     );
@@ -68,7 +74,9 @@ export async function TenantLayout({ children, params }: TenantLayoutProps) {
         className="flex min-w-0 flex-1 flex-col transition-all duration-300"
         style={{ marginLeft: sidebarWidth }}
       >
-        <main className="flex-1 pt-16">{children}</main>
+        <main className="flex-1 pt-16">
+          <ErrorBoundary>{children}</ErrorBoundary>
+        </main>
       </div>
     </div>
   );

--- a/components/shared/ErrorBoundary.tsx
+++ b/components/shared/ErrorBoundary.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+/**
+ * Generic client-side error boundary for catching rendering errors.
+ */
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown) {
+    console.error('ErrorBoundary caught an error:', error);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback ?? <div>Something went wrong.</div>;
+    }
+
+    return this.props.children;
+  }
+}

--- a/lib/actions/dashboardActions.ts
+++ b/lib/actions/dashboardActions.ts
@@ -3,11 +3,10 @@
 import { auth } from '@clerk/nextjs/server';
 import { revalidatePath } from 'next/cache';
 
-import prisma from '@/lib/database/db';
+import db from '@/lib/database/db';
 import { handleError } from '@/lib/errors/handleError';
 import { getOrganizationKPIs } from '@/lib/fetchers/kpiFetchers';
 import type { OrganizationKPIs } from '@/types/kpi';
-import db from '@/lib/database/db';
 
 export interface DashboardActionResult<T = unknown> {
   success: boolean;
@@ -27,7 +26,7 @@ export async function getDashboardOverviewAction(): Promise<
       return { success: false, error: 'Unauthorized' };
     }
 
-    const user = await prisma.user.findUnique({
+    const user = await db.user.findUnique({
       where: { clerkId: userId },
       select: { organizationId: true, role: true },
     });
@@ -83,7 +82,7 @@ export async function getDashboardAlertsAction(
     thirtyDaysFromNow.setDate(thirtyDaysFromNow.getDate() + 30);
 
     // 1. Vehicle maintenance alerts
-    const vehicleMaintenanceAlerts = await prisma.vehicle.findMany({
+    const vehicleMaintenanceAlerts = await db.vehicle.findMany({
       where: {
         organizationId,
         OR: [
@@ -150,7 +149,7 @@ export async function getDashboardAlertsAction(
     });
 
     // 2. Driver license expiration alerts
-    const driverAlerts = await prisma.driver.findMany({
+    const driverAlerts = await db.driver.findMany({
       where: {
         organizationId,
         status: 'active',
@@ -213,7 +212,7 @@ export async function getDashboardAlertsAction(
     });
 
     // 3. Load-related alerts (overdue, unassigned)
-    const overdueLoads = await prisma.load.findMany({
+    const overdueLoads = await db.load.findMany({
       where: {
         organizationId,
         status: 'assigned',
@@ -306,7 +305,7 @@ export async function getTodaysScheduleAction(
     );
 
     // Get today's scheduled pickups
-    const scheduledPickups = await prisma.load.count({
+    const scheduledPickups = await db.load.count({
       where: {
         organizationId,
         scheduledPickupDate: {
@@ -320,7 +319,7 @@ export async function getTodaysScheduleAction(
     });
 
     // Get today's scheduled deliveries
-    const scheduledDeliveries = await prisma.load.count({
+    const scheduledDeliveries = await db.load.count({
       where: {
         organizationId,
         scheduledDeliveryDate: {
@@ -334,7 +333,7 @@ export async function getTodaysScheduleAction(
     });
 
     // Get vehicles scheduled for maintenance today
-    const maintenanceScheduled = await prisma.vehicle.count({
+    const maintenanceScheduled = await db.vehicle.count({
       where: {
         organizationId,
         nextInspectionDue: {
@@ -345,7 +344,7 @@ export async function getTodaysScheduleAction(
     });
 
     // Get active loads in transit
-    const loadsInTransit = await prisma.load.count({
+    const loadsInTransit = await db.load.count({
       where: {
         organizationId,
         status: 'in_transit',
@@ -458,7 +457,7 @@ export async function getDashboardPerformanceAction(
     thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
 
     // Calculate on-time delivery rate
-    const totalDeliveries = await prisma.load.count({
+    const totalDeliveries = await db.load.count({
       where: {
         organizationId,
         status: 'delivered',
@@ -466,13 +465,13 @@ export async function getDashboardPerformanceAction(
       },
     });
 
-    const onTimeDeliveries = await prisma.load.count({
+    const onTimeDeliveries = await db.load.count({
       where: {
         organizationId,
         status: 'delivered',
         actualDeliveryDate: { 
           gte: thirtyDaysAgo,
-          lte: prisma.load.fields.scheduledDeliveryDate,
+          lte: db.load.fields.scheduledDeliveryDate,
         },
       },
     });


### PR DESCRIPTION
## Summary
- handle errors in dashboard actions with single DB client
- sync tenant layout and wrap content in an ErrorBoundary
- add reusable `ErrorBoundary` component

Closes #109

## Testing
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b964ce0ac832784adf98f4e6effaf