### PR TITLE
test: add analytics domain tests

### DIFF
--- a/lib/fetchers/analyticsFetchers.ts
+++ b/lib/fetchers/analyticsFetchers.ts
@@ -878,7 +878,7 @@ function calculateBasicMetrics(data: any[]) {
 /**
  * Calculate percentage change between two values
  */
-function calculatePercentageChange(previous: number, current: number): number {
+export function calculatePercentageChange(previous: number, current: number): number {
     if (previous === 0) return current > 0 ? 100 : 0
     return ((current - previous) / previous) * 100
 }
@@ -886,7 +886,7 @@ function calculatePercentageChange(previous: number, current: number): number {
 /**
  * Process analytics data with grouping
  */
-function processAnalyticsData(data: any[], groupBy: string) {
+export function processAnalyticsData(data: any[], groupBy: string) {
     const grouped = new Map()
 
     data.forEach(load => {

--- a/tests/analytics/dashboard-summary.test.ts
+++ b/tests/analytics/dashboard-summary.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@clerk/nextjs/server', () => ({ auth: () => Promise.resolve({ userId: 'u1' }) }));
+vi.mock('../../lib/cache/auth-cache', () => ({
+  getCachedData: () => null,
+  setCachedData: vi.fn(),
+  CACHE_TTL: { DATA: 1000 }
+}));
+
+const loadFindMany = vi.fn();
+const driverCount = vi.fn();
+const vehicleCount = vi.fn();
+const fuelAggregate = vi.fn();
+const complianceCount = vi.fn();
+
+const mockDb = {
+  load: { findMany: loadFindMany },
+  driver: { count: driverCount },
+  vehicle: { count: vehicleCount },
+  iftaFuelPurchase: { aggregate: fuelAggregate },
+  complianceAlert: { count: complianceCount }
+};
+
+vi.mock('../../lib/database/db', () => ({ __esModule: true, default: mockDb }));
+
+describe('getDashboardSummary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calculates dashboard metrics', async () => {
+    loadFindMany.mockResolvedValue([
+      { status: 'delivered', rate: 1000, actualMiles: 500, actualDeliveryDate: '2024-01-05', scheduledDeliveryDate: '2024-01-05' },
+      { status: 'in_transit', rate: 500, actualMiles: 200, actualDeliveryDate: '2024-01-08', scheduledDeliveryDate: '2024-01-07' }
+    ]);
+    driverCount.mockResolvedValue(1);
+    vehicleCount
+      .mockResolvedValueOnce(1) // active vehicles
+      .mockResolvedValueOnce(1); // maintenance vehicles
+    fuelAggregate.mockResolvedValue({ _sum: { gallons: 50 } });
+    complianceCount.mockResolvedValue(2);
+
+    const { getDashboardSummary } = await import('../../lib/fetchers/analyticsFetchers');
+    const summary = await getDashboardSummary('org1', '7d');
+    expect(summary.totalLoads).toBe(2);
+    expect(summary.completedLoads).toBe(1);
+    expect(summary.activeLoads).toBe(1);
+    expect(summary.totalRevenue).toBe(1500);
+    expect(summary.totalMiles).toBe(700);
+    expect(summary.onTimeDeliveryRate).toBe(100);
+    expect(summary.maintenanceAlerts).toBe(3);
+  });
+});

--- a/tests/analytics/report-schedule.test.ts
+++ b/tests/analytics/report-schedule.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest';
+import { POST } from '../../app/api/analytics/[orgId]/schedule/route';
+import { NextRequest } from 'next/server';
+
+vi.mock('@clerk/nextjs/server', () => ({ auth: () => Promise.resolve({ userId: 'u1' }) }));
+
+function createRequest(body: any) {
+  return new NextRequest('http://localhost/api/analytics/org1/schedule', { method: 'POST', body: JSON.stringify(body) });
+}
+
+describe('report scheduling', () => {
+  it('schedules a report and returns nextSendDate', async () => {
+    const req = createRequest({
+      name: 'Weekly',
+      frequency: 'weekly',
+      recipients: ['test@example.com'],
+      filters: {},
+      metrics: ['revenue']
+    });
+    const res = await POST(req, { params: Promise.resolve({ orgId: 'org1' }) });
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.reportId).toBeTruthy();
+    expect(json.nextSendDate).toBeTruthy();
+  });
+});

--- a/tests/analytics/utils.test.ts
+++ b/tests/analytics/utils.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@clerk/nextjs/server', () => ({ auth: () => Promise.resolve({ userId: 'u1' }) }));
+vi.mock('../../lib/cache/auth-cache', () => ({ getCachedData: () => null, setCachedData: vi.fn() }));
+vi.mock('../../lib/database/db', () => ({ __esModule: true, default: {} }));
+
+describe('analytics utils', () => {
+  it('calculates percentage change', async () => {
+    const { calculatePercentageChange } = await import('../../lib/fetchers/analyticsFetchers');
+    expect(calculatePercentageChange(100, 150)).toBe(50);
+    expect(calculatePercentageChange(0, 100)).toBe(100);
+  });
+
+  it('processes time series data by month', async () => {
+    const { processAnalyticsData } = await import('../../lib/fetchers/analyticsFetchers');
+    const data = [
+      { actualDeliveryDate: '2024-01-10', rate: 100, actualMiles: 50 },
+      { actualDeliveryDate: '2024-01-20', rate: 200, actualMiles: 100 },
+    ];
+    const result = processAnalyticsData(data as any[], 'month');
+    expect(result.length).toBe(1);
+    expect(result[0].revenue).toBe(300);
+    expect(result[0].miles).toBe(150);
+    expect(result[0].loads).toBe(2);
+  });
+});

--- a/tests/e2e/analytics.spec.ts
+++ b/tests/e2e/analytics.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Analytics dashboard', () => {
+  test('dashboard loads and export button visible', async ({ page }) => {
+    await page.goto('/');
+    await page.goto('/org1/analytics');
+    await expect(page.getByRole('heading', { name: /Analytics/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /Export/i })).toBeVisible();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,14 @@
 /** @format */
 
 import { defineConfig } from "vitest/config"
+import tsconfigPaths from "vite-tsconfig-paths"
 
 export default defineConfig({
     test: {
         environment: "node",
         globals: true,
+        include: ["tests/**/*.test.ts"],
+        exclude: ["tests/e2e/**", "node_modules/**"],
     },
+    plugins: [tsconfigPaths()],
 })


### PR DESCRIPTION
## Summary
- expand analytics fetchers with exported helpers
- configure Vitest for tsconfig paths and exclude e2e
- add unit tests for analytics utils and dashboard metrics
- test report scheduling route
- stub e2e test for analytics dashboard

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684fe6f2d63483279c058ef778be4781