### PR TITLE
Improve test coverage and structure

### DIFF
--- a/app/api/clerk/__tests__/webhook-handler.test.ts
+++ b/app/api/clerk/__tests__/webhook-handler.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+process.env.CLERK_WEBHOOK_SECRET = 'whsec_test'
+const route = () => import('../webhook-handler/route')
+
+vi.mock('svix', () => ({
+  Webhook: class {
+    verify() {
+      return { data: { id: 'evt_1' }, type: 'user.created' }
+    }
+  },
+}))
+
+vi.mock('@/lib/database/db', () => ({
+  __esModule: true,
+  default: { webhookEvent: { upsert: vi.fn() } },
+  DatabaseQueries: { upsertUser: vi.fn() },
+}))
+
+describe('webhook handler', () => {
+  it('processes Clerk event', async () => {
+    const { POST } = await route()
+    const req = new NextRequest('http://localhost/api/clerk/webhook-handler', {
+      method: 'POST',
+      body: JSON.stringify({}),
+      headers: new Headers({
+        'svix-id': '1',
+        'svix-timestamp': '1',
+        'svix-signature': 'sig',
+      }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+  })
+})

--- a/app/api/files/__tests__/upload.test.ts
+++ b/app/api/files/__tests__/upload.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST } from '../upload/route'
+
+vi.mock('@vercel/blob/client', () => ({
+  handleUpload: vi.fn(async () => ({ url: 'bloburl' })),
+}))
+
+describe('file upload route', () => {
+  it('returns upload response', async () => {
+    const req = new NextRequest('http://localhost/api/files/upload', {
+      method: 'POST',
+      body: JSON.stringify({ filename: 'file.png' }),
+      headers: new Headers({ 'content-type': 'application/json' }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+  })
+})

--- a/features/admin/__tests__/AdminDashboard.test.tsx
+++ b/features/admin/__tests__/AdminDashboard.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { AdminDashboard } from '../AdminDashboard'
+
+vi.mock('@/lib/actions/adminActions', () => ({
+  getOrganizationStatsAction: vi.fn(async () => ({
+    success: true,
+    data: {
+      userCount: 5,
+      activeUserCount: 4,
+      vehicleCount: 3,
+      driverCount: 2,
+      loadCount: 1,
+    },
+  })),
+}))
+
+describe('AdminDashboard', () => {
+  it('renders organization stats', async () => {
+    render(await AdminDashboard({ orgId: 'org1' }))
+    expect(screen.getByText('Total Users')).toBeInTheDocument()
+    expect(screen.getByText('5')).toBeInTheDocument()
+  })
+})

--- a/features/settings/__tests__/CompanySettingsPage.test.tsx
+++ b/features/settings/__tests__/CompanySettingsPage.test.tsx
@@ -1,0 +1,19 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import CompanySettingsPage from '../CompanySettingsPage'
+
+vi.mock('@/lib/fetchers/settingsFetchers', () => ({
+  getCompanyProfile: vi.fn(async () => ({ name: 'Acme Inc.' })),
+}))
+
+vi.mock('@/components/settings/CompanyProfileForm', () => ({
+  CompanyProfileForm: ({ profile }: any) => <form>Profile: {profile.name}</form>,
+}))
+
+describe('CompanySettingsPage', () => {
+  it('renders company profile form', async () => {
+    render(await CompanySettingsPage({ orgId: 'org1' }))
+    expect(screen.getByText(/Profile: Acme Inc./i)).toBeInTheDocument()
+  })
+})

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Admin users management', () => {
+  test('users page loads', async ({ page }) => {
+    await page.goto('/')
+    await page.goto('/org1/admin/users')
+    await expect(page.getByRole('heading', { name: /Users/i })).toBeVisible()
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,7 @@ import tsconfigPaths from "vite-tsconfig-paths"
 export default defineConfig({
     plugins: [tsconfigPaths()],
     test: {
-        include: ["tests/**/*.test.ts"],
+        include: ["tests/**/*.test.ts", "**/__tests__/**/*.test.ts"],
         exclude: ["tests/e2e/**", "node_modules/**"],
         environment: "node",
         globals: true,
@@ -15,5 +15,11 @@ export default defineConfig({
         coverage: {
             provider: "v8",
             reporter: ["text", "html", "json"],
+            lines: 80,
+            functions: 80,
+            branches: 80,
+            statements: 80,
+            all: true,
         },
     },
+})


### PR DESCRIPTION
## Summary
- restructure unit tests with `__tests__` folders
- add unit tests for Clerk webhook and file upload routes
- create component tests for Admin dashboard and company settings
- expand e2e coverage with an admin flow
- enforce 80% coverage thresholds in Vitest config

## Testing
- `pnpm test --run`
- `pnpm test:e2e` *(fails: 13 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68521c2ddd18832790e1180202fe4e70