### PR TITLE
config: add convention validation workflow

### DIFF
--- a/.github/workflows/fleetfusion-conventions.yml
+++ b/.github/workflows/fleetfusion-conventions.yml
@@ -1,0 +1,96 @@
+# @format
+
+# Purpose: Enforces branch and PR naming conventions
+# Triggered by: pull_request_target (opened, edited, synchronize, reopened)
+# Features: Branch prefix validation, PR title check, auto-labeling, comment updates
+
+name: "\ud83d\udded\ufe0f FleetFusion Conventions"
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  validate:
+    name: Validate Conventions
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Validate branch and title
+        id: check
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            const branch = pr.head.ref;
+            const title = pr.title;
+            const prefixRegex = /^(feature|fix|docs|test|refactor|config)\/.+/;
+            const titleRegex = /^(feat|fix|docs|test|refactor|config):\s.+/i;
+
+            const errors = [];
+            if (!prefixRegex.test(branch)) {
+              errors.push(`- Branch \`${branch}\` must start with one of: feature/, fix/, docs/, test/, refactor/, config/`);
+            }
+            if (!titleRegex.test(title)) {
+              errors.push(`- PR title must follow \`[type]: description\` (e.g., \`feat: add dashboard charts\`)`);
+            }
+
+            const labelMap = {
+              feature: 'Feature',
+              fix: 'Bug',
+              docs: 'Documentation',
+              test: 'Testing',
+              refactor: 'Code-Quality',
+              config: 'Configuration'
+            };
+            const branchType = branch.split('/')[0];
+            const label = labelMap[branchType];
+            if (label) {
+              try {
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: pr.number,
+                  labels: [label]
+                });
+              } catch (error) {
+                console.log(`Could not add label: ${error.message}`);
+              }
+            }
+
+            const header = '<!-- fleetfusion-conventions -->';
+            const body = errors.length === 0
+              ? `${header}\n\u2705 **Conventions passed**`
+              : `${header}\n## \ud83d\udea8 Convention Issues\n${errors.join('\n')}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number: pr.number
+            });
+
+            const existing = comments.find(c => c.body.startsWith(header));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pr.number,
+                body
+              });
+            }
+
+            core.setOutput('passed', errors.length === 0);
+      - name: Fail if conventions not met
+        if: steps.check.outputs.passed == 'false'
+        run: |
+          echo "Conventions check failed."
+          exit 1


### PR DESCRIPTION
## Summary
- enforce branch prefix & PR title conventions per `.models/agents.md`

## Testing
- `npm test` *(fails: Cannot find module 'vitest.setup.ts')*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_68614a3669288327b7887e51aecdf18c