### PR TITLE
feat: centralize slug generation

### DIFF
--- a/components/onboarding/OnboardingStepper.tsx
+++ b/components/onboarding/OnboardingStepper.tsx
@@ -17,6 +17,7 @@ import { ReviewSubmitStep } from "./steps/ReviewSubmitStep"
 import { RoleSelectionStep } from "./steps/RoleSelectionStep"
 
 import { completeOnboarding } from "@/lib/actions/onboardingActions"
+import { generateSlug } from "@/lib/utils/slug"
 import type { CompleteOnboardingData } from "@/schemas/onboarding"
 import type { SystemRole } from "@/types/abac"
 
@@ -146,13 +147,6 @@ export function OnboardingStepper() {
         }
     }
 
-    const generateSlug = (companyName: string): string => {
-        return companyName
-            .toLowerCase()
-            .replace(/[^a-z0-9]+/g, "-")
-            .replace(/(^-|-$)/g, "")
-            .slice(0, 50)
-    }
 
     const isAdmin = formData.role === "admin"
     const progress = ((currentStep + 1) / steps.length) * 100

--- a/lib/actions/onboardingActions.ts
+++ b/lib/actions/onboardingActions.ts
@@ -8,6 +8,7 @@ import { redirect } from "next/navigation"
 
 import db from "@/lib/database/db"
 import { handleError } from "@/lib/errors/handleError"
+import { generateSlug } from "@/lib/utils/slug"
 import {
     CompleteOnboardingSchema,
     type CompleteOnboardingData,
@@ -354,12 +355,4 @@ export async function completeOnboarding(data: CompleteOnboardingData) {
                 : "Failed to complete onboarding"
         )
     }
-}
-
-function generateSlug(companyName: string): string {
-    return companyName
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, "-")
-        .replace(/(^-|-$)/g, "")
-        .slice(0, 50)
 }

--- a/lib/utils/slug.ts
+++ b/lib/utils/slug.ts
@@ -1,0 +1,7 @@
+export function generateSlug(companyName: string): string {
+    return companyName
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/(^-|-$)/g, '')
+        .slice(0, 50);
+}


### PR DESCRIPTION
## Summary
- create `lib/utils/slug.ts`
- reuse `generateSlug` in onboarding components and actions

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test` *(fails: Invalid Chai property)*

------
https://chatgpt.com/codex/tasks/task_e_68618265f4348327b3c5377c45fab40d