### PR TITLE
[Admin] feat: Implement auth action logic (Core) (Closes #38)

### DIFF
--- a/lib/actions/authActions.ts
+++ b/lib/actions/authActions.ts
@@ -1,27 +1,144 @@
-// Auth domain server mutations
-// Add business logic for login, registration, session, and RBAC updates here
+'use server'
 
+import { clerkClient } from '@clerk/nextjs/server'
+import { signInSchema, signUpSchema, systemRoleSchema } from '@/schemas/auth'
+import db from '@/lib/database/db'
+import { sessionCache, buildSecureUserContext } from '@/lib/auth/secure-session-management'
+import { getPermissionsForRole, SystemRole } from '@/types/abac'
+import { handleError } from '@/lib/errors/handleError'
+import { z } from 'zod'
+
+/**
+ * Authenticate a user using Clerk and update the local session cache.
+ *
+ * @param email - User email address
+ * @param password - User password
+ * @returns Result object with session information or error
+ */
 export async function loginUser(email: string, password: string) {
-  // TODO: Implement login mutation
-  throw new Error('Not implemented');
+  try {
+    const { email: validatedEmail, password: validatedPassword } = signInSchema.parse({ email, password })
+    const client = await clerkClient()
+    const signIn = await client.authenticateUser({ identifier: validatedEmail, password: validatedPassword })
+    if (!signIn.sessionId || !signIn.userId) {
+      return { success: false, error: 'Invalid credentials' }
+    }
+    const session = await client.sessions.getSession(signIn.sessionId)
+    const user = await client.users.getUser(signIn.userId)
+
+    await db.user.upsert({
+      where: { id: user.id },
+      update: { lastLogin: new Date() },
+      create: {
+        id: user.id,
+        email: user.emailAddresses[0]?.emailAddress ?? validatedEmail,
+        firstName: user.firstName,
+        lastName: user.lastName,
+        profileImage: user.imageUrl,
+        onboardingComplete: true,
+      },
+    })
+
+    const userContext = buildSecureUserContext(user.id, session, (user.privateMetadata as any)?.organizationId || '')
+    sessionCache.set(`${user.id}-${userContext.organizationId}`, userContext)
+
+    return { success: true, data: { sessionId: signIn.sessionId } }
+  } catch (error) {
+    return handleError(error, 'Login User')
+  }
 }
 
-export async function registerUser(data: {
-  email: string;
-  password: string;
-  name: string;
-  companyName: string;
-}) {
-  // TODO: Implement registration mutation
-  throw new Error('Not implemented');
+/**
+ * Register a new user and associated organization using Clerk and Prisma.
+ *
+ * @param data - Registration form values
+ * @returns Result object indicating success or failure
+ */
+export async function registerUser(data: { email: string; password: string; name: string; companyName: string }) {
+  try {
+    const validated = signUpSchema.omit({ confirmPassword: true, agreeToTerms: true }).parse({
+      email: data.email,
+      password: data.password,
+      name: data.name,
+      companyName: data.companyName,
+    })
+
+    const client = await clerkClient()
+    const user = await client.users.createUser({
+      emailAddress: [validated.email],
+      password: validated.password,
+      firstName: validated.name,
+    })
+
+    const organization = await db.organization.create({ data: { name: validated.companyName, slug: validated.companyName.replace(/\s+/g, '-').toLowerCase() } })
+
+    await db.user.create({
+      data: {
+        id: user.id,
+        email: validated.email,
+        firstName: validated.name,
+        organizationId: organization.id,
+        role: 'admin',
+        onboardingComplete: true,
+      },
+    })
+
+    await client.users.updateUserMetadata(user.id, {
+      privateMetadata: { organizationId: organization.id, onboardingComplete: true },
+      publicMetadata: { organizationId: organization.id, role: 'admin', permissions: getPermissionsForRole('admin' as SystemRole) },
+    })
+
+    await updateSession(user.id)
+
+    return { success: true }
+  } catch (error) {
+    return handleError(error, 'Register User')
+  }
 }
 
+/**
+ * Refresh the user's session cache from Clerk metadata.
+ *
+ * @param userId - Clerk user identifier
+ * @returns Result object indicating success or failure
+ */
 export async function updateSession(userId: string) {
-  // TODO: Implement session update logic
-  throw new Error('Not implemented');
+  try {
+    const client = await clerkClient()
+    const user = await client.users.getUser(userId)
+    const sessions = await client.users.getUserSessions(userId)
+    const session = sessions[0]
+    if (!session) {
+      return { success: false, error: 'No active session' }
+    }
+    const context = buildSecureUserContext(user.id, session, (user.privateMetadata as any)?.organizationId || '')
+    sessionCache.set(`${user.id}-${context.organizationId}`, context)
+    return { success: true }
+  } catch (error) {
+    return handleError(error, 'Update Session')
+  }
 }
 
+/**
+ * Update a user's role and permissions across tenants.
+ *
+ * @param userId - Clerk user identifier
+ * @param role - New system role
+ * @returns Result object indicating success or failure
+ */
 export async function updateRBAC(userId: string, role: string) {
-  // TODO: Implement RBAC update logic
-  throw new Error('Not implemented');
+  try {
+    const parsed = systemRoleSchema.parse(role) as SystemRole
+    const client = await clerkClient()
+    const permissions = getPermissionsForRole(parsed)
+    await client.users.updateUserMetadata(userId, {
+      publicMetadata: { role: parsed, permissions },
+    })
+    await db.user.update({ where: { id: userId }, data: { role: parsed } })
+    sessionCache.invalidateUser(userId)
+    await updateSession(userId)
+    return { success: true }
+  } catch (error) {
+    return handleError(error, 'Update RBAC')
+  }
 }


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: admin
Milestone: Core

## Description
Adds implementations for the auth server actions using Clerk and Prisma. Passwords are validated with Zod, Clerk metadata is updated for multi‑tenant RBAC, and user sessions are cached via `secure-session-management`.

## Related Issue
Closes #38 - Admin feat: implement auth domain server actions (Core)

## Wave Dependencies
- Builds on: initial auth action stubs
- Enables: further auth features in upcoming waves
- Cross-domain integration: session management, database persistence

## Domain Impact
- Primary domain: admin
- Files modified: `lib/actions/authActions.ts`
- Integration points: Clerk, Prisma, session cache

## Milestone Compliance
- [ ] Meets Core complexity requirements
- [ ] Aligns with milestone delivery goals
- [ ] No scope creep beyond milestone definition

## Wave Completion
- [ ] Domain task completed for current wave
- [ ] Dependencies resolved or properly managed
- [ ] Ready for wave progression

## Testing Performed
- [ ] Domain-specific functionality verified
- [ ] Cross-domain integrations tested
- [ ] Wave dependencies validated
- [ ] Milestone requirements met

`npm test` failed due to missing vitest setup file.

------
https://chatgpt.com/codex/tasks/task_e_68885684c2308327b2dbb3da241c5ed1