### PR TITLE
[Admin] feat: Validate organization ID on employee join (MVP) (Closes #38)

### DIFF
--- a/components/onboarding/EmployeeJoinStep.tsx
+++ b/components/onboarding/EmployeeJoinStep.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { verifyOrganizationExists } from '@/lib/fetchers/onboardingFetchers';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
@@ -30,6 +31,9 @@ export function EmployeeJoinStep({ formData, updateFormData, onNext, onPrev }: E
   
   const isValid = formData.organizationId.trim();
 
+  /**
+   * Validates the organization ID before moving to the next step.
+   */
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!isValid) return;
@@ -38,15 +42,18 @@ export function EmployeeJoinStep({ formData, updateFormData, onNext, onPrev }: E
     setValidationError('');
 
     try {
-      // TODO: Validate organization ID exists
-      // For now, we'll just proceed
-      setTimeout(() => {
+      // Verify the organization exists before allowing the user to proceed
+      const exists = await verifyOrganizationExists(formData.organizationId);
+      if (!exists) {
+        setValidationError('Organization not found. Please check the ID and try again.');
         setIsValidating(false);
-        onNext();
-      }, 1000);
-      
+        return;
+      }
+
+      onNext();
     } catch (error) {
       setValidationError('Organization not found. Please check the ID and try again.');
+    } finally {
       setIsValidating(false);
     }
   };

--- a/lib/fetchers/onboardingFetchers.ts
+++ b/lib/fetchers/onboardingFetchers.ts
@@ -78,3 +78,22 @@ export async function getUserOnboardingProgress(id: string) {
     handleDatabaseError(error);
   }
 }
+
+/**
+ * Verify that an organization exists for the provided identifier.
+ * Accepts either the organization UUID or slug.
+ * Used during onboarding to validate the organization ID.
+ */
+export async function verifyOrganizationExists(orgId: string): Promise<boolean> {
+  try {
+    const organization = await db.organization.findFirst({
+      where: {
+        OR: [{ id: orgId }, { slug: orgId }],
+      },
+      select: { id: true },
+    });
+    return !!organization;
+  } catch (error) {
+    handleDatabaseError(error);
+  }
+}


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: admin
Milestone: MVP

## Description
Implemented server-side validation when an employee attempts to join an organization. The join form now calls a new server fetcher to verify the organization ID and shows an error if not found.

## Related Issue
Closes #38 - Admin Feature: Validate organization ID (MVP)

## Wave Dependencies
- Builds on: initial onboarding forms
- Enables: further onboarding flows
- Cross-domain integration: none

## Domain Impact
- Primary domain: admin
- Files modified: `components/onboarding/EmployeeJoinStep.tsx`, `lib/fetchers/onboardingFetchers.ts`
- Integration points: onboarding join flow

## Milestone Compliance
- [x] Meets MVP complexity requirements
- [x] Aligns with milestone delivery goals
- [x] No scope creep beyond milestone definition

## Wave Completion
- [x] Domain task completed for current wave
- [ ] Dependencies resolved or properly managed
- [ ] Ready for wave progression

## Testing Performed
- [ ] Domain-specific functionality verified
- [ ] Cross-domain integrations tested
- [ ] Wave dependencies validated
- [ ] Milestone requirements met

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_688856864af88327bbddf45f9e7e44ee