### PR TITLE
[Analytics] feat: add filter preset persistence (Core) (Closes #38)

### DIFF
--- a/docs/Developer-Documentation.md
+++ b/docs/Developer-Documentation.md
@@ -61,7 +61,8 @@ and organization management are handled through Clerk's service, enabling multi-
     for filings.
 -   **Analytics & Reporting:** Offer dashboards and reports for key metrics like fleet utilization,
     on-time delivery rate, fuel efficiency, and costs. Allow filtering and drill-down to investigate
-    specific aspects of operations.
+    specific aspects of operations. Users can save analytics filter presets for frequently used views.
+    Presets are returned with defaults listed first.
 -   **Settings & Configuration:** Allow admins to configure company-wide settings such as user roles,
     notification preferences, and possibly billing information. This includes managing which users
     have which roles within the platform.

--- a/lib/fetchers/analyticsFetchers.ts
+++ b/lib/fetchers/analyticsFetchers.ts
@@ -588,32 +588,22 @@ export async function saveFilterPreset(
         throw new Error("Unauthorized")
     }
     try {
-        // TODO: Implement analytics filter preset creation when model is added to schema
-        // const filterPreset = await prisma.analyticsFilterPreset.create({
-        //     data: {
-        //         name: preset.name,
-        //         filters: preset.filters as any, // Store as JSON
-        //         userId,
-        //         organizationId,
-        //         isDefault: preset.isDefault || false,
-        //     },
-        // })
+        const filterPreset = await prisma.analyticsFilterPreset.create({
+            data: {
+                name: preset.name,
+                description: (preset as any).description ?? null,
+                filters: preset.filters as any,
+                userId,
+                organizationId,
+                isDefault: preset.isDefault ?? false,
+            },
+        })
 
-        const filterPreset = {
-            id: Math.random().toString(36),
-            name: preset.name,
-            filters: preset.filters,
-            organizationId,
-            userId,
-            isDefault: preset.isDefault || false,
-            createdAt: new Date(),
-            updatedAt: new Date(),
-        }
+        // Invalidate cached presets for the user
+        const cacheKey = `analytics:presets:${organizationId}:${userId}`
+        setCachedData(cacheKey, null as any, 0)
 
-        return {
-            success: true,
-            data: filterPreset,
-        }
+        return { success: true, data: filterPreset }
     } catch (error) {
         console.error("Error saving filter preset:", error)
         throw new Error("Failed to save filter preset")
@@ -635,16 +625,13 @@ export async function getFilterPresets(organizationId: string): Promise<any> {
         return cached
     }
     try {
-        // TODO: Implement analytics filter preset retrieval when model is added to schema
-        // const presets = await prisma.analyticsFilterPreset.findMany({
-        //     where: {
-        //         organizationId,
-        //         userId,
-        //     },
-        //     orderBy: [{ isDefault: "desc" }, { name: "asc" }],
-        // })
-
-        const presets: any[] = [] // Temporary empty array until model is implemented
+        const presets = await prisma.analyticsFilterPreset.findMany({
+            where: {
+                organizationId,
+                userId,
+            },
+            orderBy: [{ isDefault: "desc" }, { name: "asc" }],
+        })
 
         setCachedData(cacheKey, presets, CACHE_TTL.DATA)
         return presets

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -42,7 +42,8 @@ model Organization {
   vehicles            Vehicle[]
   trailers            Trailer[]
   customers           Customer[]  
-  dispatchActivities  DispatchActivity[]  
+  dispatchActivities  DispatchActivity[]
+  analyticsFilterPresets AnalyticsFilterPreset[]
 
   @@index([slug])
   @@map("organizations")
@@ -73,6 +74,7 @@ model User {
   driver                        Driver?
   IftaReport                    IftaReport[]             @relation("SubmittedByUser")
   memberships                   OrganizationMembership[]
+  analyticsFilterPresets        AnalyticsFilterPreset[]
   organization                  Organization?            @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   @@index([organizationId])
@@ -601,6 +603,24 @@ model IftaTaxCalculation {
   calculatedByUser User       @relation("CalculatedByUser", fields: [calculatedBy], references: [id])
   report           IftaReport @relation(fields: [reportId], references: [id])
   validatedByUser  User?      @relation("ValidatedByUser", fields: [validatedBy], references: [id])
+}
+
+model AnalyticsFilterPreset {
+  id             String       @id @default(uuid())
+  organizationId String       @map("organization_id")
+  userId         String       @map("user_id")
+  name           String
+  description    String?
+  filters        Json         @map("filters")
+  isDefault      Boolean      @default(false) @map("is_default")
+  createdAt      DateTime     @default(now()) @map("created_at")
+  updatedAt      DateTime     @updatedAt @map("updated_at")
+  user           User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  @@index([organizationId])
+  @@index([userId])
+  @@map("analytics_filter_presets")
 }
 
 enum UserRole {


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: analytics
Milestone: Core

## Description
Adds Prisma model for analytics filter presets and implements server actions to create and retrieve presets. Retrieval now orders presets with defaults first. Documentation updated accordingly.

## Related Issue
Closes #38 - Analytics Feature: Persist filter presets (Core)

## Wave Dependencies
- Builds on: initial analytics fetching utilities
- Enables: future preset management UI
- Cross-domain integration: none

## Domain Impact
- Primary domain: analytics
- Files modified: `lib/fetchers/analyticsFetchers.ts`, `prisma/schema.prisma`, `docs/Developer-Documentation.md`
- Integration points: Prisma client

## Milestone Compliance
- [x] Meets Core complexity requirements
- [x] Aligns with milestone delivery goals
- [x] No scope creep beyond milestone definition

## Wave Completion
- [x] Domain task completed for current wave
- [x] Dependencies resolved or properly managed
- [x] Ready for wave progression

## Testing Performed
- [x] `npm run type-check`
- [x] `npm test` *(fails: vitest setup missing)*

------
https://chatgpt.com/codex/tasks/task_e_6888568d16e4832788f07be09decc55c