### PR TITLE
[IFTA] feat: filter report lookup by quarter dates (Core) (Closes #38)

### DIFF
--- a/lib/fetchers/iftaFetchers.ts
+++ b/lib/fetchers/iftaFetchers.ts
@@ -170,14 +170,16 @@ export async function getIftaDataForPeriod(
       }
     });
 
-    // Check for existing IFTA report for this period  
-    // Note: Quarter and year fields don't exist in current schema
-    // This would need to be implemented using calculationData or date ranges
+    // Check for existing IFTA report for this period
     const existingReport = await db.iftaReport.findFirst({
       where: {
         organizationId: orgId,
-        // TODO: Implement quarter/year filtering using date ranges or calculationData
+        createdAt: {
+          gte: startDate,
+          lte: endDate,
+        },
       },
+      orderBy: { createdAt: 'desc' },
     });
 
     const result: IftaPeriodData = {

--- a/tests/domains/ifta/getIftaDataForPeriod.test.ts
+++ b/tests/domains/ifta/getIftaDataForPeriod.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@clerk/nextjs/server', () => ({ auth: () => Promise.resolve({ userId: 'u1' }) }))
+vi.mock('../../../lib/cache/auth-cache', () => ({
+  getCachedData: () => null,
+  setCachedData: vi.fn(),
+  CACHE_TTL: { SHORT: 60 }
+}))
+
+const findUnique = vi.fn()
+const tripFindMany = vi.fn()
+const fuelFindMany = vi.fn()
+const reportFindFirst = vi.fn()
+
+vi.mock('../../../lib/database/db', () => ({
+  __esModule: true,
+  default: {
+    user: { findUnique },
+    iftaTrip: { findMany: tripFindMany },
+    iftaFuelPurchase: { findMany: fuelFindMany },
+    iftaReport: { findFirst: reportFindFirst }
+  }
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  findUnique.mockResolvedValue({ organizationId: 'org1', role: 'admin' })
+  tripFindMany.mockResolvedValue([])
+  fuelFindMany.mockResolvedValue([])
+})
+
+describe('getIftaDataForPeriod', () => {
+  it('filters reports by quarter date range', async () => {
+    const mockReport = { id: 'r1', status: 'submitted', submittedAt: new Date('2024-04-15'), dueDate: new Date('2024-04-30') }
+    reportFindFirst.mockResolvedValue(mockReport)
+
+    const { getIftaDataForPeriod } = await import('../../../lib/fetchers/iftaFetchers')
+    const result = await getIftaDataForPeriod('org1', 'Q1', '2024')
+
+    const args = reportFindFirst.mock.calls[0][0]
+    expect(args.where.organizationId).toBe('org1')
+    expect(args.where.createdAt.gte).toEqual(new Date(2024, 0, 1))
+    expect(args.where.createdAt.lte).toEqual(new Date(2024, 3, 0, 23, 59, 59))
+    expect(result.report).toEqual({
+      id: 'r1',
+      status: 'submitted',
+      submittedAt: mockReport.submittedAt,
+      dueDate: mockReport.dueDate
+    })
+  })
+
+  it('returns null when no report exists in range', async () => {
+    reportFindFirst.mockResolvedValue(null)
+
+    const { getIftaDataForPeriod } = await import('../../../lib/fetchers/iftaFetchers')
+    const result = await getIftaDataForPeriod('org1', 'Q2', '2024')
+
+    expect(result.report).toBeNull()
+  })
+})

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+// Vitest setup


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: ifta
Milestone: Core

## Description
Implemented date range filtering for existing IFTA reports in `getIftaDataForPeriod` and added unit tests. Created minimal test setup file to satisfy Vitest configuration.

## Related Issue
Closes #38 - [IFTA] Feature: Period data filtering (Core)

## Wave Dependencies
- Builds on: none
- Enables: future quarterly reporting tasks
- Cross-domain integration: none

## Domain Impact
- Primary domain: ifta
- Files modified: `lib/fetchers/iftaFetchers.ts`, `tests/domains/ifta/getIftaDataForPeriod.test.ts`, `vitest.setup.ts`
- Integration points: none

## Milestone Compliance
- [x] Meets Core complexity requirements
- [x] Aligns with milestone delivery goals
- [x] No scope creep beyond milestone definition

## Wave Completion
- [x] Domain task completed for current wave
- [x] Dependencies resolved or properly managed
- [x] Ready for wave progression

## Testing Performed
- [x] Unit tests added and executed for new logic
- [ ] Full test suite *(failed due to missing environment variables)*


------
https://chatgpt.com/codex/tasks/task_e_6888568ecfc08327bf8ef607ccaa575f