### PR TITLE
[IFTA] feat: implement pdf generation service (Core) (Closes #38)

### DIFF
--- a/lib/services/pdfService.ts
+++ b/lib/services/pdfService.ts
@@ -2,6 +2,11 @@
  * PDF Service for IFTA Report Generation
  * Handles PDF generation for quarterly reports, trip logs, and fuel summaries
  */
+import { PDFDocument, StandardFonts, rgb } from 'pdf-lib'
+import { writeFile, mkdir } from 'fs/promises'
+import { existsSync } from 'fs'
+import path from 'path'
+
 
 export interface PDFOptions {
   format: 'Letter' | 'A4';
@@ -28,6 +33,13 @@ export interface PDFGenerationResult {
   };
 }
 
+export interface PDFAttachment {
+  name: string;
+  data: Uint8Array;
+  mimeType?: string;
+  description?: string;
+}
+
 export interface CustomReportOptions extends PDFOptions {
   reportType: string;
   dateRange?: {
@@ -44,6 +56,14 @@ export interface CustomReportOptions extends PDFOptions {
 }
 
 class PDFService {
+  private async ensureOrgDir(orgId: string): Promise<string> {
+    const dir = path.join(process.cwd(), 'generated-reports', orgId)
+    if (!existsSync(dir)) {
+      await mkdir(dir, { recursive: true })
+    }
+    return dir
+  }
+
   /**
    * Generate quarterly IFTA report PDF
    */
@@ -51,24 +71,66 @@ class PDFService {
     orgId: string,
     quarter: string,
     year: number,
-    options: PDFOptions
+    options: PDFOptions,
+    attachments: PDFAttachment[] = []
   ): Promise<PDFGenerationResult> {
     try {
-      // TODO: Implement actual PDF generation
-      const fileName = `ifta-quarterly-${quarter}-${year}.pdf`;
-      const filePath = `/generated-reports/${orgId}/${fileName}`;
-        return {
+      const dir = await this.ensureOrgDir(orgId)
+      const size = options.format === 'A4' ? [595.28, 841.89] : [612, 792]
+      const pageSize =
+        options.orientation === 'landscape' ? [size[1], size[0]] : size
+
+      const pdfDoc = await PDFDocument.create()
+      const page = pdfDoc.addPage(pageSize)
+      const font = await pdfDoc.embedFont(StandardFonts.Helvetica)
+
+      page.drawText(`Quarterly IFTA Report - Q${quarter} ${year}`, {
+        x: 50,
+        y: pageSize[1] - 50,
+        size: 16,
+        font,
+        color: rgb(0, 0, 0),
+      })
+
+      if (options.watermark && options.watermark !== 'none') {
+        const wmFont = await pdfDoc.embedFont(StandardFonts.Helvetica)
+        page.drawText(options.watermark.toUpperCase(), {
+          x: pageSize[0] / 2 - 100,
+          y: pageSize[1] / 2,
+          size: 50,
+          font: wmFont,
+          color: rgb(0.85, 0.85, 0.85),
+          rotate: { type: 'degrees', angle: 45 },
+        })
+      }
+
+      if (options.includeAttachments) {
+        for (const att of attachments) {
+          await pdfDoc.attach(att.data, att.name, {
+            mimeType: att.mimeType ?? 'application/octet-stream',
+            description: att.description ?? att.name,
+          })
+        }
+      }
+
+      const pdfBytes = await pdfDoc.save()
+      const fileName = `ifta-quarterly-${quarter}-${year}.pdf`
+      const filePath = path.join(dir, fileName)
+
+      await writeFile(filePath, pdfBytes)
+
+      return {
         success: true,
         filePath,
         fileName,
-        fileSize: 1024,
+        fileSize: pdfBytes.length,
         metadata: {
-          pageCount: 5,
+          pageCount: pdfDoc.getPageCount(),
           version: '1.0',
           generatedAt: new Date(),
           reportType: 'QUARTERLY',
         },
-      };
+      }
     } catch (error) {
       return {
         success: false,
@@ -82,24 +144,66 @@ class PDFService {
    */
   async generateTripLogReport(
     orgId: string,
-    options: CustomReportOptions
+    options: CustomReportOptions,
+    attachments: PDFAttachment[] = []
   ): Promise<PDFGenerationResult> {
     try {
-      // TODO: Implement actual PDF generation
-      const fileName = `ifta-trip-log-${Date.now()}.pdf`;
-      const filePath = `/generated-reports/${orgId}/${fileName}`;
-        return {
+      const dir = await this.ensureOrgDir(orgId)
+      const size = options.format === 'A4' ? [595.28, 841.89] : [612, 792]
+      const pageSize =
+        options.orientation === 'landscape' ? [size[1], size[0]] : size
+
+      const pdfDoc = await PDFDocument.create()
+      const page = pdfDoc.addPage(pageSize)
+      const font = await pdfDoc.embedFont(StandardFonts.Helvetica)
+
+      page.drawText('IFTA Trip Log', {
+        x: 50,
+        y: pageSize[1] - 50,
+        size: 16,
+        font,
+        color: rgb(0, 0, 0),
+      })
+
+      if (options.watermark && options.watermark !== 'none') {
+        const wmFont = await pdfDoc.embedFont(StandardFonts.Helvetica)
+        page.drawText(options.watermark.toUpperCase(), {
+          x: pageSize[0] / 2 - 100,
+          y: pageSize[1] / 2,
+          size: 50,
+          font: wmFont,
+          color: rgb(0.85, 0.85, 0.85),
+          rotate: { type: 'degrees', angle: 45 },
+        })
+      }
+
+      if (options.includeAttachments) {
+        for (const att of attachments) {
+          await pdfDoc.attach(att.data, att.name, {
+            mimeType: att.mimeType ?? 'application/octet-stream',
+            description: att.description ?? att.name,
+          })
+        }
+      }
+
+      const pdfBytes = await pdfDoc.save()
+      const fileName = `ifta-trip-log-${Date.now()}.pdf`
+      const filePath = path.join(dir, fileName)
+
+      await writeFile(filePath, pdfBytes)
+
+      return {
         success: true,
         filePath,
         fileName,
-        fileSize: 2048,
+        fileSize: pdfBytes.length,
         metadata: {
-          pageCount: 8,
+          pageCount: pdfDoc.getPageCount(),
           version: '1.0',
           generatedAt: new Date(),
           reportType: 'TRIP_LOG',
         },
-      };
+      }
     } catch (error) {
       return {
         success: false,
@@ -113,24 +217,66 @@ class PDFService {
    */
   async generateFuelSummaryReport(
     orgId: string,
-    options: CustomReportOptions
+    options: CustomReportOptions,
+    attachments: PDFAttachment[] = []
   ): Promise<PDFGenerationResult> {
     try {
-      // TODO: Implement actual PDF generation
-      const fileName = `ifta-fuel-summary-${Date.now()}.pdf`;
-      const filePath = `/generated-reports/${orgId}/${fileName}`;
-        return {
+      const dir = await this.ensureOrgDir(orgId)
+      const size = options.format === 'A4' ? [595.28, 841.89] : [612, 792]
+      const pageSize =
+        options.orientation === 'landscape' ? [size[1], size[0]] : size
+
+      const pdfDoc = await PDFDocument.create()
+      const page = pdfDoc.addPage(pageSize)
+      const font = await pdfDoc.embedFont(StandardFonts.Helvetica)
+
+      page.drawText('IFTA Fuel Summary', {
+        x: 50,
+        y: pageSize[1] - 50,
+        size: 16,
+        font,
+        color: rgb(0, 0, 0),
+      })
+
+      if (options.watermark && options.watermark !== 'none') {
+        const wmFont = await pdfDoc.embedFont(StandardFonts.Helvetica)
+        page.drawText(options.watermark.toUpperCase(), {
+          x: pageSize[0] / 2 - 100,
+          y: pageSize[1] / 2,
+          size: 50,
+          font: wmFont,
+          color: rgb(0.85, 0.85, 0.85),
+          rotate: { type: 'degrees', angle: 45 },
+        })
+      }
+
+      if (options.includeAttachments) {
+        for (const att of attachments) {
+          await pdfDoc.attach(att.data, att.name, {
+            mimeType: att.mimeType ?? 'application/octet-stream',
+            description: att.description ?? att.name,
+          })
+        }
+      }
+
+      const pdfBytes = await pdfDoc.save()
+      const fileName = `ifta-fuel-summary-${Date.now()}.pdf`
+      const filePath = path.join(dir, fileName)
+
+      await writeFile(filePath, pdfBytes)
+
+      return {
         success: true,
         filePath,
         fileName,
-        fileSize: 1536,
+        fileSize: pdfBytes.length,
         metadata: {
-          pageCount: 6,
+          pageCount: pdfDoc.getPageCount(),
           version: '1.0',
           generatedAt: new Date(),
           reportType: 'FUEL_SUMMARY',
         },
-      };
+      }
     } catch (error) {
       return {
         success: false,


### PR DESCRIPTION
## Wave & Domain Context
Wave: 3
Domain: ifta
Milestone: Core

## Description
Implement real PDF generation using pdf-lib for quarterly, trip log and fuel summary reports. Supports watermarking and attachments. Files are saved under `/generated-reports/{orgId}` and metadata returned via `PDFGenerationResult`.

## Related Issue
Closes #38 - [IFTA] Feature: PDF generation service (Core)

## Wave Dependencies
- Builds on: none
- Enables: future report distribution features
- Cross-domain integration: none

## Domain Impact
- Primary domain: ifta
- Files modified: `lib/services/pdfService.ts`
- Integration points: none

## Milestone Compliance
- [x] Meets Core complexity requirements
- [x] Aligns with milestone delivery goals
- [x] No scope creep beyond milestone definition

## Wave Completion
- [x] Domain task completed for current wave
- [x] Dependencies resolved or properly managed
- [x] Ready for wave progression

## Testing Performed
- [ ] Domain-specific functionality verified
- [ ] Cross-domain integrations tested
- [ ] Wave dependencies validated
- [ ] Milestone requirements met

Tests failed due to missing vitest setup in the environment.

------
https://chatgpt.com/codex/tasks/task_e_68885692eda08327bd93cc526a9bec89