### PR TITLE
[Settings] feat: Add runtime auth feature flag (Core) (Closes #38)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,8 +38,12 @@ BLOB_READ_WRITE_TOKEN="vercel_blob_..."
 GOOGLE_MAPS_API_KEY="AIza..."
 
 # Feature Flags
+NEXT_PUBLIC_ENABLE_AUTH=true
 NEXT_PUBLIC_ENABLE_ANALYTICS=true
 NEXT_PUBLIC_ENABLE_REAL_TIME=false
+
+# Feature Management Service (optional)
+FEATURE_SERVICE_URL=""
 
 # Performance Monitoring
 DATABASE_LOGGING=true

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ npm run dev
 
 Open [http://localhost:3000](http://localhost:3000)
 
+## Feature Flags
+FleetFusion supports runtime toggles via environment variables. See [docs/feature-flags.md](./docs/feature-flags.md) for details.
+
 ---
 
 ## 🆘 Help & Support

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -1,0 +1,17 @@
+# Feature Flags
+
+FleetFusion allows certain features to be toggled at runtime via environment variables or a remote feature management service.
+
+## NEXT_PUBLIC_ENABLE_AUTH
+
+- **Description:** Enables Clerk authentication and route protection.
+- **Default:** `true`
+- **Usage:** Set `NEXT_PUBLIC_ENABLE_AUTH=false` in your environment to disable authentication. If this variable is not set, FleetFusion attempts to fetch the flag from the service defined by `FEATURE_SERVICE_URL`.
+
+## FEATURE_SERVICE_URL
+
+- **Description:** Optional HTTP endpoint returning feature flag settings.
+- **Format:** `https://your-flags-service.com/api`
+- **Usage:** When provided, `isAuthFeatureEnabled` will fetch `/auth` from this service if no environment variable is set.
+
+The helper `isAuthFeatureEnabled` in `lib/config/featureFlags.ts` exposes the flag state for runtime checks.

--- a/lib/config/featureFlags.ts
+++ b/lib/config/featureFlags.ts
@@ -1,0 +1,18 @@
+export async function isAuthFeatureEnabled(): Promise<boolean> {
+  const envFlag = process.env.NEXT_PUBLIC_ENABLE_AUTH
+  if (envFlag !== undefined) {
+    return envFlag === 'true'
+  }
+  const serviceUrl = process.env.FEATURE_SERVICE_URL
+  if (serviceUrl) {
+    try {
+      const res = await fetch(`${serviceUrl}/auth`)
+      if (!res.ok) return false
+      const data = (await res.json()) as { enabled?: boolean }
+      return data.enabled === true
+    } catch {
+      return false
+    }
+  }
+  return false
+}


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: settings
Milestone: Core

## Description
Adds a runtime feature flag for authentication. The `isAuthFeatureEnabled()` helper reads the `NEXT_PUBLIC_ENABLE_AUTH` environment variable or falls back to a remote flag service specified by `FEATURE_SERVICE_URL`.

## Related Issue
Closes #38 - Settings Feature: Add runtime auth feature flag (Core)

## Wave Dependencies
- Builds on: none
- Enables: future runtime control for auth related tasks
- Cross-domain integration: authentication flows

## Domain Impact
- Primary domain: settings
- Files modified: `.env.example`, `README.md`, `lib/config/featureFlags.ts`, `docs/feature-flags.md`
- Integration points: auth middleware can check `isAuthFeatureEnabled`

## Milestone Compliance
- [x] Meets Core complexity requirements
- [x] Aligns with milestone delivery goals
- [x] No scope creep beyond milestone definition

## Wave Completion
- [x] Domain task completed for current wave
- [x] Dependencies resolved or properly managed
- [x] Ready for wave progression

## Testing Performed
- [ ] Domain-specific functionality verified
- [ ] Cross-domain integrations tested
- [ ] Wave dependencies validated
- [ ] Milestone requirements met

Test run output attached in the PR comments.

------
https://chatgpt.com/codex/tasks/task_e_68885696a6cc8327b931440134dd4af3