### PR TITLE
[Compliance] feat: add notification and audit models (Core) (Closes #38)

### DIFF
--- a/lib/fetchers/dashboardFetchers.ts
+++ b/lib/fetchers/dashboardFetchers.ts
@@ -74,21 +74,20 @@ export async function getOrganizationUsers(orgId: string): Promise<UserManagemen
 
 export async function getAuditLogs(orgId: string): Promise<AuditLogEntry[]> {
   await requireAdminForOrg(orgId);
-  
-  // TODO: AuditLog model not yet implemented in schema
-  // const logs = await prisma.auditLog.findMany({
-  //   where: { organizationId: orgId },
-  //   orderBy: { timestamp: 'desc' },
-  // });
-  // return logs.map(l => ({
-  //   id: l.id,
-  //   userId: l.userId || '',
-  //   action: l.action,
-  //   target: l.entityType + ':' + l.entityId,
-  //   createdAt: l.timestamp.toISOString(),
-  // }));
-  
-  return [];
+
+  const logs = await prisma.auditLog.findMany({
+    where: { organizationId: orgId },
+    orderBy: { timestamp: 'desc' },
+    take: 100,
+  })
+
+  return logs.map(l => ({
+    id: l.id,
+    userId: l.userId || '',
+    action: l.action,
+    target: `${l.entityType}:${l.entityId}`,
+    createdAt: l.timestamp.toISOString(),
+  }))
 }
 
 export async function getBillingInfo(orgId: string): Promise<BillingInfo> {

--- a/lib/fetchers/notificationFetchers.ts
+++ b/lib/fetchers/notificationFetchers.ts
@@ -4,6 +4,7 @@
 
 import type { Notification } from "@/types/notifications"
 import { auth } from "@clerk/nextjs/server"
+import db from "@/lib/database/db"
 
 /**
  * List unread notifications for the current user within an organization.
@@ -14,28 +15,24 @@ export async function listUnreadNotifications(
     const { userId } = await auth()
     if (!userId) return []
 
-    // TODO: Implement notification model when added to schema
-    // const notifications = await db.notification.findMany({
-    //   where: {
-    //     organizationId: orgId,
-    //     OR: [
-    //       { userId },
-    //       { userId: null } // Global notifications
-    //     ],
-    //     readAt: null,
-    //   },
-    //   orderBy: { createdAt: 'desc' },
-    //   take: 10,
-    // });
+    const notifications = await db.notification.findMany({
+        where: {
+            organizationId: orgId,
+            OR: [{ userId }, { userId: null }],
+            readAt: null,
+        },
+        orderBy: { createdAt: "desc" },
+        take: 10,
+    })
 
-    const notifications: Notification[] = [] // Temporary empty array until model is implemented
-
-    // Convert Date fields to string for Notification type compatibility
-    return notifications.map((n: any) => ({
-        ...n,
-        createdAt: n.createdAt.toISOString(),
-        updatedAt: n.updatedAt.toISOString(),
+    return notifications.map((n) => ({
+        id: n.id,
+        organizationId: n.organizationId,
+        userId: n.userId,
+        message: n.message,
+        url: n.url,
         readAt: n.readAt ? n.readAt.toISOString() : null,
+        createdAt: n.createdAt.toISOString(),
     }))
 }
 
@@ -46,9 +43,8 @@ export async function markNotificationRead(id: string): Promise<void> {
     const { userId } = await auth()
     if (!userId) return
 
-    // TODO: Implement notification model when added to schema
-    // await db.notification.update({
-    //   where: { id },
-    //   data: { readAt: new Date() },
-    // });
+    await db.notification.update({
+        where: { id },
+        data: { readAt: new Date() },
+    })
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,6 +30,7 @@ model Organization {
   updatedAt           DateTime                 @updatedAt @map("updated_at")
   dotNumber           String?
   auditLogs           AuditLog[]
+  notifications       Notification[]
   complianceAlerts    ComplianceAlert[]
   complianceDocuments ComplianceDocument[]
   drivers             Driver[]
@@ -69,6 +70,7 @@ model User {
   calculatedIftaTaxCalculations IftaTaxCalculation[]     @relation("CalculatedByUser")
   validatedIftaTaxCalculations  IftaTaxCalculation[]     @relation("ValidatedByUser")
   auditLogs                     AuditLog[]
+  notifications                 Notification[]
   ComplianceDocument            ComplianceDocument[]     @relation("VerifiedByUser")
   driver                        Driver?
   IftaReport                    IftaReport[]             @relation("SubmittedByUser")
@@ -395,6 +397,25 @@ model AuditLog {
   @@index([action])
   @@index([timestamp])
   @@map("audit_logs")
+}
+
+model Notification {
+  id             String       @id @default(uuid())
+  organizationId String       @map("organization_id")
+  userId         String?      @map("user_id")
+  message        String
+  url            String?      @map("url")
+  readAt         DateTime?    @map("read_at")
+  createdAt      DateTime     @default(now()) @map("created_at")
+  updatedAt      DateTime     @updatedAt @map("updated_at")
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  user           User?        @relation(fields: [userId], references: [id])
+
+  @@index([organizationId])
+  @@index([userId])
+  @@index([readAt])
+  @@index([createdAt])
+  @@map("notifications")
 }
 
 model WebhookEvent {


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: compliance
Milestone: Core

## Description
Adds Prisma models for `Notification` and integrates the existing `AuditLog` model. Notification fetchers now persist and read notifications from the database and `getAuditLogs` reads real entries. Notification records include `organizationId` and `userId` to support RBAC.

## Related Issue
Closes #38 - Compliance feat: Implement audit trail management (Core)

## Wave Dependencies
- Builds on: initial schema setup
- Enables: future notification UI work
- Cross-domain integration: none

## Domain Impact
- Primary domain: compliance
- Files modified: `lib/fetchers/notificationFetchers.ts`, `lib/fetchers/dashboardFetchers.ts`, `prisma/schema.prisma`
- Integration points: Prisma client fetchers

## Milestone Compliance
- [x] Meets Core complexity requirements
- [x] Aligns with milestone delivery goals
- [x] No scope creep beyond milestone definition

## Wave Completion
- [x] Domain task completed for current wave
- [ ] Dependencies resolved or properly managed
- [ ] Ready for wave progression

## Testing Performed
- [x] `npm test` *(fails: missing vitest.setup.ts)*
- [x] `npx prisma generate`


------
https://chatgpt.com/codex/tasks/task_e_6888569437048327919e22e336beec86