### PR TITLE
[Analytics] docs: add JSDoc for feature components (MVP) (Closes #38)

### DIFF
--- a/features/analytics/MainDashboardFeature.tsx
+++ b/features/analytics/MainDashboardFeature.tsx
@@ -4,6 +4,14 @@ import { getDashboardSummary } from '@/lib/fetchers/analyticsFetchers';
 interface MainDashboardFeatureProps {
   orgId: string;
 }
+/**
+ * Server component for the main analytics dashboard overview.
+ *
+ * @param props.orgId - Organization identifier used to load summary data.
+ *
+ * Cards reflow from single column on mobile to grid on larger screens.
+ */
+// See docs/screenshots/dashboard-overview.png for spacing
 
 export async function MainDashboardFeature({
   orgId,

--- a/features/analytics/dashboard-metrics.tsx
+++ b/features/analytics/dashboard-metrics.tsx
@@ -61,6 +61,14 @@ function MetricCard({
 interface DashboardMetricsProps {
   orgId: string;
 }
+/**
+ * Server component displaying key metrics for the dashboard.
+ *
+ * @param props.orgId - Organization identifier to load metrics.
+ *
+ * Metric cards wrap from two columns on tablets to four columns on desktop.
+ */
+// See docs/screenshots/dashboard-metrics-cards.png for layout
 
 const DashboardMetrics: FC<DashboardMetricsProps> = async ({ orgId }) => {
   if (!orgId) {

--- a/features/analytics/performance-metrics.tsx
+++ b/features/analytics/performance-metrics.tsx
@@ -21,6 +21,15 @@ interface PerformanceMetricsProps {
   timeRange: string;
   performanceData: RevenueMetrics[]; // Updated prop type to RevenueMetrics
 }
+/**
+ * Client chart component for performance trends over time.
+ *
+ * @param props.timeRange - Selected range of data.
+ * @param props.performanceData - Metrics for loads, miles, and more.
+ *
+ * Charts resize responsively using Recharts containers.
+ */
+// See docs/screenshots/performance-metrics.png for reference
 
 export function PerformanceMetrics({
   performanceData,

--- a/features/compliance/ComplianceDashboard.tsx
+++ b/features/compliance/ComplianceDashboard.tsx
@@ -4,6 +4,14 @@ import { getComplianceDashboard } from '@/lib/fetchers/complianceFetchers';
 interface ComplianceDashboardProps {
   orgId: string;
 }
+/**
+ * Server component displaying compliance statistics.
+ *
+ * @param props.orgId - Organization identifier used to load compliance data.
+ *
+ * Metrics grid adapts from two to three columns responsively.
+ */
+// See docs/screenshots/compliance-dashboard.png for visuals
 
 export async function ComplianceDashboard({ orgId }: ComplianceDashboardProps) {
   if (!orgId) {

--- a/features/vehicles/VehicleListPage.tsx
+++ b/features/vehicles/VehicleListPage.tsx
@@ -8,6 +8,15 @@ interface VehicleListPageProps {
   page?: number;
 }
 
+/**
+ * Server component showing the paginated vehicle list for an organization.
+ *
+ * @param props.orgId - Organization identifier used to fetch vehicles.
+ * @param props.page - Optional page index, defaults to the first page.
+ *
+ * Layout adapts using flex utilities for mobile and desktop views.
+ */
+// See docs/screenshots/vehicle-list-page.png for example layout
 export default async function VehicleListPage({
   orgId,
   page = 1,
@@ -19,7 +28,7 @@ export default async function VehicleListPage({
 
   return (
     <div className="flex flex-col gap-6 p-6 bg-neutral-900 text-white min-h-screen">
-      {/* Fleet Vehicles Header */}
+      {/* Fleet Vehicles Header - see docs/screenshots/vehicles-header.png for spacing */}
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold tracking-tight text-white">Fleet Vehicles</h1>

--- a/features/vehicles/add-vehicle-dialog.tsx
+++ b/features/vehicles/add-vehicle-dialog.tsx
@@ -41,6 +41,16 @@ const initialState: Partial<VehicleFormData> = {
   licensePlateState: '',
 };
 
+/**
+ * Client dialog for adding a new vehicle to the organization.
+ *
+ * @param props.orgId - Organization identifier for the vehicle.
+ * @param props.onSuccess - Callback fired when creation succeeds.
+ * @param props.open - Whether the dialog is open.
+ * @param props.onOpenChange - Triggered when dialog visibility changes.
+ *
+ * Uses responsive grid inputs for small and large screens.
+ */
 export default function AddVehicleDialog({
   orgId,
   onSuccess,
@@ -98,6 +108,7 @@ export default function AddVehicleDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
+      {/* See docs/screenshots/add-vehicle-dialog.png for layout reference */}
       <DialogContent className="sm:max-w-[500px] bg-neutral-900 border-muted text-white">
         <DialogHeader>
           <DialogTitle className="text-white">Add New Vehicle</DialogTitle>

--- a/features/vehicles/edit-vehicle-dialog.tsx
+++ b/features/vehicles/edit-vehicle-dialog.tsx
@@ -17,6 +17,17 @@ interface Props {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
+/**
+ * Client dialog for editing an existing vehicle.
+ *
+ * @param props.orgId - Organization identifier used for mutation.
+ * @param props.vehicle - Current vehicle details, null when not loaded.
+ * @param props.onSuccess - Callback when update succeeds.
+ * @param props.open - Whether the dialog is open.
+ * @param props.onOpenChange - Triggered on open state change.
+ *
+ * Form layout switches between stacked and grid based on screen size.
+ */
 
 export default function EditVehicleDialog({
   orgId,
@@ -95,6 +106,7 @@ export default function EditVehicleDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
+      {/* See docs/screenshots/edit-vehicle-dialog.png for layout reference */}
       <DialogContent className="sm:max-w-[500px] bg-neutral-900 border-muted text-white">
         <DialogHeader>
           <DialogTitle className="text-white">Edit Vehicle</DialogTitle>
@@ -237,3 +249,14 @@ export default function EditVehicleDialog({
     </Dialog>
   );
 }
+/**
+ * Client dialog for editing an existing vehicle.
+ *
+ * @param props.orgId - Organization identifier used for mutation.
+ * @param props.vehicle - Current vehicle details, null when not loaded.
+ * @param props.onSuccess - Callback when update succeeds.
+ * @param props.open - Whether the dialog is open.
+ * @param props.onOpenChange - Triggered on open state change.
+ *
+ * Form layout switches between stacked and grid based on screen size.
+ */


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: analytics
Milestone: MVP

## Description
Adds JSDoc comments and screenshot references for exported components across analytics, vehicles and compliance features.

## Related Issue
Closes #38 - Analytics docs: improve component comments (MVP)

## Wave Dependencies
- Builds on: none
- Enables: future documentation cleanup tasks
- Cross-domain integration: vehicles, compliance

## Domain Impact
- Primary domain: analytics
- Files modified: main/src/features/analytics/*, main/src/features/vehicles/*, main/src/features/compliance/*
- Integration points: none

## Milestone Compliance
- [ ] Meets MVP complexity requirements
- [ ] Aligns with milestone delivery goals
- [ ] No scope creep beyond milestone definition

## Wave Completion
- [ ] Domain task completed for current wave
- [ ] Dependencies resolved or properly managed
- [ ] Ready for wave progression

## Testing Performed
- [ ] `npm test` *(failed: vitest not installed)*
- [ ] `npm run type-check` *(failed: existing type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6888b0d74688832796917a54c35d8599