### PR TITLE
[Admin] feat: Implement auth feature flag check (MVP) (Closes #38)

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -14,4 +14,4 @@ FleetFusion allows certain features to be toggled at runtime via environment var
 - **Format:** `https://your-flags-service.com/api`
 - **Usage:** When provided, `isAuthFeatureEnabled` will fetch `/auth` from this service if no environment variable is set.
 
-The helper `isAuthFeatureEnabled` in `lib/config/featureFlags.ts` exposes the flag state for runtime checks.
+The helper `isAuthFeatureEnabled` in `lib/config/featureFlags.ts` is re-exported from `features/auth` for easy importing and exposes the flag state for runtime checks.

--- a/features/auth/index.ts
+++ b/features/auth/index.ts
@@ -1,8 +1,8 @@
 // Auth domain business logic entry point
 //
-// TODO remaining: implement feature flag logic to toggle auth flows.
+// Exposes feature flag helpers and auth utilities.
 
-export function isAuthFeatureEnabled() {
-  // TODO: Implement feature flag logic
-  return true;
-}
+import { isAuthFeatureEnabled as checkAuthFeature } from '@/lib/config/featureFlags'
+
+// Re-export feature flag helper so consumers can import from this domain module
+export const isAuthFeatureEnabled = checkAuthFeature


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: admin
Milestone: MVP

## Description
Adds a re-export of the `isAuthFeatureEnabled` helper from `features/auth` and updates the feature flags documentation.

## Related Issue
Closes #38 - [Admin] feat: Implement auth feature flag helper (MVP)

## Wave Dependencies
- none

## Domain Impact
- Primary domain: admin
- Files modified: features/auth/index.ts, docs/feature-flags.md
- Integration points: none

## Milestone Compliance
- [x] Meets MVP complexity requirements
- [x] Aligns with milestone delivery goals
- [x] No scope creep beyond milestone definition

## Wave Completion
- [ ] Domain task completed for current wave
- [ ] Dependencies resolved or properly managed
- [ ] Ready for wave progression

## Testing Performed
- [ ] Domain-specific functionality verified
- [ ] Cross-domain integrations tested
- [ ] Wave dependencies validated
- [ ] Milestone requirements met

The automated test suite was executed but failed.


------
https://chatgpt.com/codex/tasks/task_e_6888b0da76cc8327a46eaaf4d247e6f8