### PR TITLE
[Docs] docs: add testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ npm run dev
 
 Open [http://localhost:3000](http://localhost:3000)
 
+### Running Tests
+
+Install project dependencies before running tests:
+
+```bash
+npm install
+npm test
+```
+
 ## Feature Flags
 FleetFusion supports runtime toggles via environment variables. See [docs/feature-flags.md](./docs/feature-flags.md) for details.
 


### PR DESCRIPTION
## Summary
- document running tests with npm install first

## Related Issue
Closes #38?

## Testing
- `npm test` *(fails: vitest suite)*

------
https://chatgpt.com/codex/tasks/task_e_6888b0dce54c8327b78b5468e8c60dda