### PR TITLE
[Onboarding] fix: remove timeout from org verification (MVP) (Closes #38)

### DIFF
--- a/components/onboarding/EmployeeJoinStep.tsx
+++ b/components/onboarding/EmployeeJoinStep.tsx
@@ -41,16 +41,10 @@ export function EmployeeJoinStep({ formData, updateFormData, onNext, onPrev }: E
     setIsValidating(true);
     setValidationError('');
 
-    try {
-      // TODO: Validate organization ID exists once org lookup API is available
-      // For now, we'll just proceed
-      setTimeout(() => {
-      // Verify the organization exists before allowing the user to proceed
+  try {
       const exists = await verifyOrganizationExists(formData.organizationId);
       if (!exists) {
         setValidationError('Organization not found. Please check the ID and try again.');
-         main
-        setIsValidating(false);
         return;
       }
 


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: settings?? Wait domain is onboarding (maybe settings). But not specified.
Milestone: MVP

## Description
Removed the unnecessary `setTimeout` and stray text in `EmployeeJoinStep`. Now verifies organization existence directly in the try/catch and resets `isValidating` in finally.

## Related Issue
Closes #38 - Onboarding Bug: Form validation fix (MVP)

## Wave Dependencies
- None

## Domain Impact
- Primary domain: settings? (since features not specified)

## Milestone Compliance
- [ ] Meets MVP complexity requirements

## Wave Completion
- [ ] Domain task completed for current wave

## Testing Performed
- [ ] `npm test` (fails)


------
https://chatgpt.com/codex/tasks/task_e_6888b22d8a3c8327b734d0838c4532bc