### PR TITLE
[Drivers] feat: add vehicle and driver list skeletons (Core) (Closes #38)

### DIFF
--- a/app/(tenant)/[orgId]/drivers/page.tsx
+++ b/app/(tenant)/[orgId]/drivers/page.tsx
@@ -1,4 +1,4 @@
-import { DriversSkeleton } from '@/components/drivers/drivers-skeleton';
+import { DriverListSkeleton } from '@/components/drivers/driver-list-skeleton';
 import { Suspense } from 'react';
 import DriversListHeader from '@/components/drivers/drivers-list-header';
 import DriversList from '@/features/drivers/DriversList';
@@ -15,12 +15,12 @@ export default async function DriverListPage({ params, searchParams }: PageProps
   return (
     <div className="flex flex-col gap-6 p-6 bg-neutral-900 text-white min-h-screen">
       {/* Drivers List Header */}
-      <Suspense fallback={<DriversSkeleton />}>
+      <Suspense fallback={<DriverListSkeleton />}>
         <DriversListHeader />
       </Suspense>
 
       {/* Driver Tabs */}
-      <Suspense fallback={<DriversSkeleton />}>
+      <Suspense fallback={<DriverListSkeleton />}>
         <DriversList orgId={orgId} searchParams={resolvedSearchParams} />
       </Suspense>
     </div>

--- a/app/(tenant)/[orgId]/vehicles/page.tsx
+++ b/app/(tenant)/[orgId]/vehicles/page.tsx
@@ -3,6 +3,7 @@ import { listVehiclesByOrg } from '@/lib/fetchers/vehicleFetchers';
 import { Plus } from 'lucide-react';
 import Link from 'next/link';
 import VehiclesClient from './vehicles-client';
+import { VehicleListSkeleton } from '@/components/vehicles/vehicle-list-skeleton';
 
 interface VehiclesPageProps {
   params: Promise<{ orgId: string }>;
@@ -28,7 +29,7 @@ export default async function VehiclesPage({ params }: VehiclesPageProps) {
         </Link>
       </div>
       
-      <Suspense fallback={<div className="text-white/70">Loading vehicles...</div>}>
+      <Suspense fallback={<VehicleListSkeleton />}>
         <VehiclesClient orgId={orgId} initialVehicles={vehicles} />
       </Suspense>
     </div>

--- a/components/drivers/driver-list-skeleton.tsx
+++ b/components/drivers/driver-list-skeleton.tsx
@@ -1,0 +1,45 @@
+import { Skeleton } from '@/components/ui/skeleton';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+
+/**
+ * DriverListSkeleton
+ *
+ * Placeholder skeleton for the driver list page.
+ * Mirrors the layout of search, tabs and card grid.
+ */
+export function DriverListSkeleton() {
+  return (
+    <div className="space-y-6">
+      {/* Search and Filter */}
+      <div className="flex flex-col sm:flex-row gap-4">
+        <Skeleton className="h-10 flex-1 bg-gray-800" />
+        <Skeleton className="h-10 w-20 sm:w-10 bg-gray-800" />
+      </div>
+      {/* Tabs */}
+      <div className="grid w-full grid-cols-3 bg-black border border-muted">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={i} className="h-10 bg-gray-800" />
+        ))}
+      </div>
+      {/* Driver Cards Grid */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mt-4">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Card key={i} className="border-muted rounded-md border bg-neutral-900">
+            <CardHeader className="flex flex-row items-center gap-4 space-y-0 pb-2">
+              <Skeleton className="h-12 w-12 rounded-full bg-gray-700" />
+              <div className="flex-1 space-y-2">
+                <Skeleton className="h-4 w-1/2 bg-gray-700" />
+                <Skeleton className="h-3 w-1/3 bg-gray-700" />
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <Skeleton className="h-3 w-3/4 bg-gray-700" />
+              <Skeleton className="h-3 w-2/3 bg-gray-700" />
+              <Skeleton className="h-3 w-1/2 bg-gray-700" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/vehicles/vehicle-list-skeleton.tsx
+++ b/components/vehicles/vehicle-list-skeleton.tsx
@@ -1,0 +1,35 @@
+import { Skeleton } from '@/components/ui/skeleton';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+
+/**
+ * VehicleListSkeleton
+ *
+ * Placeholder skeleton for the vehicle list page.
+ * Mirrors the spacing and card shapes of the final layout.
+ */
+export function VehicleListSkeleton() {
+  return (
+    <div className="space-y-6">
+      {/* Search and Add Vehicle */}
+      <div className="flex flex-col sm:flex-row gap-4">
+        <Skeleton className="h-10 flex-1 bg-gray-800" />
+        <Skeleton className="h-10 w-32 bg-gray-800" />
+      </div>
+      {/* Vehicle Cards Grid */}
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Card key={i} className="border-muted rounded-md border bg-neutral-900">
+            <CardHeader className="pb-2">
+              <Skeleton className="h-4 w-1/2 bg-gray-700" />
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <Skeleton className="h-3 w-full bg-gray-700" />
+              <Skeleton className="h-3 w-2/3 bg-gray-700" />
+              <Skeleton className="h-3 w-1/2 bg-gray-700" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/features/vehicles/VehicleListPage.tsx
+++ b/features/vehicles/VehicleListPage.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react';
 
 import { listVehiclesByOrg } from '@/lib/fetchers/vehicleFetchers';
 import VehicleListClient from '@/components/vehicles/vehicle-list-client';
+import { VehicleListSkeleton } from '@/components/vehicles/vehicle-list-skeleton';
 
 interface VehicleListPageProps {
   orgId: string;
@@ -27,7 +28,7 @@ export default async function VehicleListPage({
         </div>
       </div>
       
-      <Suspense fallback={<div className="text-white/70">Loading vehicles...</div>}>
+      <Suspense fallback={<VehicleListSkeleton />}>
         <VehicleListClient orgId={orgId} initialVehicles={vehicles} />
       </Suspense>
     </div>


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: drivers
Milestone: Core

## Description
Implemented skeleton placeholders for vehicle and driver list pages. Updated the relevant pages to use these skeletons as `<Suspense>` fallbacks so loading states match the final layout.

## Related Issue
Closes #38 - Drivers feature: Implement skeletons for list pages (Core)

## Wave Dependencies
- Builds on: none
- Enables: future list page enhancements
- Cross-domain integration: vehicles

## Domain Impact
- Primary domain: drivers
- Files modified: `app/(tenant)/[orgId]/drivers/page.tsx`, `app/(tenant)/[orgId]/vehicles/page.tsx`, `features/vehicles/VehicleListPage.tsx`, new components under `components/drivers` and `components/vehicles`
- Integration points: page loading states

## Milestone Compliance
- [x] Meets Core complexity requirements
- [x] Aligns with milestone delivery goals
- [x] No scope creep beyond milestone definition

## Wave Completion
- [x] Domain task completed for current wave
- [x] Dependencies resolved or properly managed
- [x] Ready for wave progression

## Testing Performed
- [ ] `npm test` *(fails: see log)*

------
https://chatgpt.com/codex/tasks/task_e_6888b2393a308327a845c4290b91fb72