### PR TITLE
[Settings] feat: finalize auth flag retrieval (Core) (Closes #38)

### DIFF
--- a/features/auth/index.ts
+++ b/features/auth/index.ts
@@ -1,8 +1,20 @@
 // Auth domain business logic entry point
-//
-// TODO remaining: implement feature flag logic to toggle auth flows.
 
-export function isAuthFeatureEnabled() {
-  // TODO: Implement feature flag logic
-  return true;
+export async function isAuthFeatureEnabled(): Promise<boolean> {
+  const envFlag = process.env.NEXT_PUBLIC_ENABLE_AUTH
+  if (envFlag !== undefined) {
+    return envFlag === 'true'
+  }
+  const serviceUrl = process.env.FEATURE_SERVICE_URL
+  if (serviceUrl) {
+    try {
+      const res = await fetch(`${serviceUrl}/auth`)
+      if (!res.ok) return false
+      const data = (await res.json()) as { enabled?: boolean }
+      return data.enabled === true
+    } catch {
+      return false
+    }
+  }
+  return false
 }

--- a/tests/lib/auth/isAuthFeatureEnabled.test.ts
+++ b/tests/lib/auth/isAuthFeatureEnabled.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import { isAuthFeatureEnabled } from '../../../features/auth'
+
+const originalEnv = { ...process.env }
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  process.env = { ...originalEnv }
+})
+
+afterEach(() => {
+  process.env = { ...originalEnv }
+})
+
+describe('isAuthFeatureEnabled', () => {
+  it('returns true when NEXT_PUBLIC_ENABLE_AUTH=true', async () => {
+    process.env.NEXT_PUBLIC_ENABLE_AUTH = 'true'
+    const result = await isAuthFeatureEnabled()
+    expect(result).toBe(true)
+  })
+
+  it('returns false when NEXT_PUBLIC_ENABLE_AUTH=false', async () => {
+    process.env.NEXT_PUBLIC_ENABLE_AUTH = 'false'
+    const result = await isAuthFeatureEnabled()
+    expect(result).toBe(false)
+  })
+
+  it('fetches from FEATURE_SERVICE_URL when env var is undefined', async () => {
+    process.env.NEXT_PUBLIC_ENABLE_AUTH = undefined as any
+    process.env.FEATURE_SERVICE_URL = 'https://flags.example.com'
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => ({ enabled: true }) }) as any
+    const result = await isAuthFeatureEnabled()
+    expect(fetch).toHaveBeenCalledWith('https://flags.example.com/auth')
+    expect(result).toBe(true)
+  })
+
+  it('returns false when fetch fails', async () => {
+    process.env.NEXT_PUBLIC_ENABLE_AUTH = undefined as any
+    process.env.FEATURE_SERVICE_URL = 'https://flags.example.com'
+    global.fetch = vi.fn().mockRejectedValue(new Error('fail')) as any
+    const result = await isAuthFeatureEnabled()
+    expect(result).toBe(false)
+  })
+})


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: settings
Milestone: Core

## Description
Implements the runtime flag logic for authentication. `isAuthFeatureEnabled` now checks the `NEXT_PUBLIC_ENABLE_AUTH` environment variable and falls back to a remote service defined by `FEATURE_SERVICE_URL`. Added unit tests validating the flag behaviour.

## Related Issue
Closes #38 - [Settings] feat: finalize auth flag retrieval (Core)

## Wave Dependencies
- Builds on: previous flag management utilities
- Enables: future conditional auth logic
- Cross-domain integration: none

## Domain Impact
- Primary domain: settings
- Files modified: `features/auth/index.ts`, `tests/lib/auth/isAuthFeatureEnabled.test.ts`
- Integration points: feature flag configuration

## Milestone Compliance
- [x] Meets Core complexity requirements
- [x] Aligns with milestone delivery goals
- [x] No scope creep beyond milestone definition

## Wave Completion
- [x] Domain task completed for current wave
- [x] Dependencies resolved or properly managed
- [x] Ready for wave progression

## Testing Performed
- [x] Domain-specific functionality verified
- [ ] Cross-domain integrations tested
- [ ] Wave dependencies validated
- [x] Milestone requirements met


------
https://chatgpt.com/codex/tasks/task_e_6888b4d4c2a083279cdc0534af140976