### PR TITLE
[IFTA] enhancement: improve quarterly data queries (Core) (Closes #38)

### DIFF
--- a/tests/domains/ifta/getIftaDataForPeriod.test.ts
+++ b/tests/domains/ifta/getIftaDataForPeriod.test.ts
@@ -9,15 +9,19 @@ vi.mock('../../../lib/cache/auth-cache', () => ({
 
 const findUnique = vi.fn()
 const tripFindMany = vi.fn()
+const tripAggregate = vi.fn()
+const tripGroupBy = vi.fn()
 const fuelFindMany = vi.fn()
+const fuelAggregate = vi.fn()
+const fuelGroupBy = vi.fn()
 const reportFindFirst = vi.fn()
 
 vi.mock('../../../lib/database/db', () => ({
   __esModule: true,
   default: {
     user: { findUnique },
-    iftaTrip: { findMany: tripFindMany },
-    iftaFuelPurchase: { findMany: fuelFindMany },
+    iftaTrip: { findMany: tripFindMany, aggregate: tripAggregate, groupBy: tripGroupBy },
+    iftaFuelPurchase: { findMany: fuelFindMany, aggregate: fuelAggregate, groupBy: fuelGroupBy },
     iftaReport: { findFirst: reportFindFirst }
   }
 }))
@@ -26,7 +30,11 @@ beforeEach(() => {
   vi.clearAllMocks()
   findUnique.mockResolvedValue({ organizationId: 'org1', role: 'admin' })
   tripFindMany.mockResolvedValue([])
+  tripAggregate.mockResolvedValue({ _sum: { distance: 0 } })
+  tripGroupBy.mockResolvedValue([])
   fuelFindMany.mockResolvedValue([])
+  fuelAggregate.mockResolvedValue({ _sum: { gallons: 0, amount: 0 } })
+  fuelGroupBy.mockResolvedValue([])
 })
 
 describe('getIftaDataForPeriod', () => {
@@ -39,8 +47,8 @@ describe('getIftaDataForPeriod', () => {
     const args = reportFindFirst.mock.calls[0]![0]
 
     expect(args.where.organizationId).toBe('org1')
-    expect(args.where.createdAt.gte).toEqual(new Date(2024, 0, 1))
-    expect(args.where.createdAt.lte).toEqual(new Date(2024, 3, 0, 23, 59, 59))
+    expect(args.where.quarter).toBe(1)
+    expect(args.where.year).toBe(2024)
     expect(result.report).toEqual({
       id: 'r1',
       status: 'submitted',


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: ifta
Milestone: Core

## Description
Implemented direct quarter/year filtering in Prisma queries and replaced manual reductions with Prisma `groupBy`/`aggregate`. Trip records now join load data to populate driver and location details. Updated IFTA report queries use quarter/year fields and removed related TODOs.

## Related Issue
Closes #38 - [IFTA] Enhancement: improve data fetch logic (Core)

## Wave Dependencies
- Builds on: initial IFTA data fetchers
- Enables: future advanced reporting tasks
- Cross-domain integration: none

## Domain Impact
- Primary domain: ifta
- Files modified: `lib/fetchers/iftaFetchers.ts`, `tests/domains/ifta/getIftaDataForPeriod.test.ts`
- Integration points: load lookups for trip data

## Milestone Compliance
- [x] Meets Core complexity requirements
- [x] Aligns with milestone delivery goals
- [x] No scope creep beyond milestone definition

## Wave Completion
- [x] Domain task completed for current wave
- [ ] Dependencies resolved or properly managed
- [ ] Ready for wave progression

## Testing Performed
- [x] `npx vitest run tests/domains/ifta/getIftaDataForPeriod.test.ts`
- [ ] `npm run lint` *(failed: ESLint not installed)*


------
https://chatgpt.com/codex/tasks/task_e_6888c2d3c07c8327abae9743462681de