### PR TITLE
[Admin] enhancement: include invitation result details (MVP) (Closes #38)

### DIFF
--- a/lib/actions/userActions.ts
+++ b/lib/actions/userActions.ts
@@ -1,8 +1,6 @@
 "use server";
 /**
  * User management server actions.
- *
- * TODO remaining: send invitation emails when inviting users.
  */
 import db from "@/lib/database/db";
 import { handleError } from "@/lib/errors/handleError";
@@ -55,7 +53,7 @@ export async function inviteUserAction(
     const link = `${baseUrl}/accept-invitation?token=${token}`;
     await sendInvitationEmail(email, link);
 
-    return { success: true };
+    return { success: true, userId: user.id, invitationToken: token };
   } catch (error) {
     return handleError(error, "Invite User Action");
   }

--- a/types/actions.ts
+++ b/types/actions.ts
@@ -6,3 +6,10 @@ export interface ActionResult<T> {
 
 export type AdminActionResult<T> = ActionResult<T>;
 export type AnalyticsActionResult<T> = ActionResult<T>;
+
+export interface UserInvitationResult {
+  success: boolean;
+  userId?: string;
+  invitationToken?: string;
+  error?: string;
+}


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: admin
Milestone: MVP

## Description
Removed obsolete TODO from `inviteUserAction` and updated the action to return the ID of the invited user and the generated invitation token. Added a `UserInvitationResult` interface in `types/actions.ts` documenting this return type.

## Related Issue
Closes #38 - Admin Enhancement: Include invitation result details (MVP)

## Wave Dependencies
- Builds on: initial admin actions
- Enables: future invitation tracking features
- Cross-domain integration: none

## Domain Impact
- Primary domain: admin
- Files modified: `lib/actions/userActions.ts`, `types/actions.ts`
- Integration points: invitation email workflow

## Milestone Compliance
- [x] Meets MVP complexity requirements
- [x] Aligns with milestone delivery goals
- [x] No scope creep beyond milestone definition

## Wave Completion
- [x] Domain task completed for current wave
- [x] Dependencies resolved or properly managed
- [x] Ready for wave progression

## Testing Performed
- [ ] Domain-specific functionality verified
- [ ] Cross-domain integrations tested
- [ ] Wave dependencies validated
- [ ] Milestone requirements met

Test run shows failing tests:
```
Test Files  6 failed | 19 passed (25)
     Tests  9 failed | 39 passed (48)
```


------
https://chatgpt.com/codex/tasks/task_e_6888c8988b5c8327a7a2fb70f4748c30