### PR TITLE
chore: add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run type-check
+      - run: npm test
+
+  deploy:
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - name: Deploy to Vercel
+        uses: amondnet/vercel-action@v25
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          working-directory: .
+          prod: true
+

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ FleetFusion supports runtime toggles via environment variables. See [docs/featur
 -   **Project Board**: All issues/PRs are tracked on the
     [Project Board](https://github.com/users/DigitalHerencia/projects/4).
 -   **Milestones**: Features are grouped by release milestones (e.g., Q3 2025).
--   **Merge Conflicts**: See our [Merge Conflict Resolution Guide](./docs/merge-conflict-resolution.md) for step-by-step help.
+  -   **Merge Conflicts**: See our [Merge Conflict Resolution Guide](./docs/merge-conflict-resolution.md) for step-by-step help.
+  -   **CI Pipeline**: Automated via GitHub Actions in [`ci.yml`](.github/workflows/ci.yml) to lint, type-check, test, and deploy to Vercel.
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for full guidelines.
 

--- a/docs/Developer-Documentation.md
+++ b/docs/Developer-Documentation.md
@@ -199,7 +199,7 @@ support these product requirements._
 -   **Vercel Deployment:** The application is deployed on Vercel, which handles building and serving
     the Next.js app. Commits to the main branch trigger Vercel to build and deploy the latest version.
     Vercel handles scaling, SSL (HTTPS), and CDN distribution automatically.
--   **CI/CD Pipeline:** A GitHub Actions workflow is set up to automate testing and deployment:
+  -   **CI/CD Pipeline:** A GitHub Actions workflow (see `.github/workflows/ci.yml`) is set up to automate testing and deployment:
 
     -   On push or merge to `main`, the workflow runs the test suite and build process.
     -   If tests pass, it uses Vercel's CLI or API (with stored credentials) to initiate a deployment of
@@ -485,7 +485,7 @@ practices:
     changes are pushed to the `main` branch (after passing tests), Vercel will automatically build and
     deploy the new version. This provides a seamless deployment process, where code merges result in
     live updates to the app.
--   **Continuous Integration (CI):** GitHub Actions handle testing and integration steps:
+-   **Continuous Integration (CI):** GitHub Actions (see `.github/workflows/ci.yml`) handle testing and integration steps:
 
     -   A typical workflow might run on every pull request and push to `main`. It will install
         dependencies, run `eslint` for linting, run `tsc` for type checks, and execute all tests.


### PR DESCRIPTION
## Summary
- set up GitHub Actions workflow for lint, type checks, tests and Vercel deploy
- document CI workflow in README and Developer documentation

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `npm run type-check` *(fails with TypeScript errors)*
- `npm test` *(fails with multiple failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_6888e11750cc8327992a6270933c8490