### PR TITLE
[Admin] feat: implement session claims endpoint (Core) (Closes #38)

### DIFF
--- a/app/api/clerk/__tests__/session-claims.test.ts
+++ b/app/api/clerk/__tests__/session-claims.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { NextRequest } from 'next/server';
+const route = () => import('../session-claims/route');
+
+describe('session claims endpoint', () => {
+  it('returns claims for user', async () => {
+    const user = {
+      id: 'user1',
+      first_name: 'Test',
+      last_name: 'User',
+      email_addresses: [{ email_address: 'test@example.com' }],
+      public_metadata: {
+        role: 'admin',
+        permissions: ['perm'],
+        onboardingComplete: true,
+        organizationId: 'org1',
+      },
+      private_metadata: { organizationId: 'org1', isActive: true },
+      last_sign_in_at: '2024-01-01T00:00:00Z',
+    };
+    const req = new NextRequest('http://localhost/api/clerk/session-claims', {
+      method: 'POST',
+      body: JSON.stringify({ user, session: { last_active_at: '2024-01-01T00:00:00Z' } }),
+    });
+    const { POST } = await route();
+    const res = await POST(req);
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json['user.id']).toBe('user1');
+    expect(json.abac.organizationId).toBe('org1');
+    expect(json.abac.role).toBe('admin');
+    expect(json.firstName).toBe('Test');
+  });
+});

--- a/app/api/clerk/session-claims/route.ts
+++ b/app/api/clerk/session-claims/route.ts
@@ -1,0 +1,52 @@
+"use server";
+
+import { NextRequest, NextResponse } from 'next/server';
+import { validateSessionClaims, createTestSessionClaims } from '@/lib/auth/session-claims-utils';
+import type { SystemRole } from '@/types/abac';
+
+export async function POST(req: NextRequest) {
+  try {
+    const { user, session } = await req.json();
+    if (!user || !user.id) {
+      return NextResponse.json({ error: 'Missing user data' }, { status: 400 });
+    }
+
+    const role = (user.public_metadata?.role as SystemRole) || 'member';
+    const organizationId =
+      user.private_metadata?.organizationId ||
+      user.public_metadata?.organizationId ||
+      '';
+
+    const claims = createTestSessionClaims({
+      userId: user.id,
+      organizationId,
+      role,
+      onboardingComplete: user.public_metadata?.onboardingComplete ?? false,
+    });
+
+    // Enrich with real user info
+    claims.firstName = user.first_name ?? claims.firstName;
+    claims.lastName = user.last_name ?? claims.lastName;
+    claims.primaryEmail = user.email_addresses?.[0]?.email_address ?? claims.primaryEmail;
+    claims.fullName = `${user.first_name ?? ''} ${user.last_name ?? ''}`.trim() || claims.fullName;
+    if (session?.last_active_at) {
+      claims.metadata = {
+        ...claims.metadata,
+        lastLogin: new Date(session.last_active_at).toISOString(),
+      };
+    }
+
+    const validation = validateSessionClaims(claims);
+    if (!validation.isValid) {
+      return NextResponse.json(
+        { error: 'Invalid claims', details: validation.errors },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json(claims);
+  } catch (error) {
+    console.error('[session-claims]', error);
+    return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+  }
+}


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: admin
Milestone: Core

## Description
Adds Clerk session claims API endpoint using existing utilities and introduces tests verifying JSON output for authenticated users.

## Related Issue
Closes #38 - [Admin] Feature: Clerk session claims endpoint (Core)

## Wave Dependencies
- Builds on: none
- Enables: future auth flows
- Cross-domain integration: none

## Domain Impact
- Primary domain: admin
- Files modified: app/api/clerk/session-claims/route.ts
- Integration points: Clerk authentication

## Milestone Compliance
- [ ] Meets Core complexity requirements
- [ ] Aligns with milestone delivery goals
- [ ] No scope creep beyond milestone definition

## Wave Completion
- [ ] Domain task completed for current wave
- [ ] Dependencies resolved or properly managed
- [ ] Ready for wave progression

## Testing Performed
- [ ] Domain-specific functionality verified
- [ ] Cross-domain integrations tested
- [ ] Wave dependencies validated
- [ ] Milestone requirements met


------
https://chatgpt.com/codex/tasks/task_e_6888e1180a288327ac187b1c7b700c31