### PR TITLE
[Dispatch] enhancement: refine dispatch board recent activity (Core) (Closes #38)

### DIFF
--- a/app/(tenant)/[orgId]/dispatch/[userId]/page.tsx
+++ b/app/(tenant)/[orgId]/dispatch/[userId]/page.tsx
@@ -44,14 +44,14 @@ export default async function DispatchPage({ params }: DispatchPageProps) {
     <div className="flex flex-col gap-6 p-6 bg-neutral-900 text-white min-h-screen">
       {/* Header - Real-time status & connection */}
       <Suspense fallback={<DispatchSkeleton />}>
-        <DispatchHeader orgId={orgId} userId={userId} />
+        <DispatchHeader orgId={orgId} />
       </Suspense>
 
       {/* Recent Activity & Quick Actions */}
       <RecentActivityRow
         params={{ userId }}
         stats={summaryStats}
-        RecentActivity={recentActivity.data.map((activity) => ({
+        activities={recentActivity.data.map((activity) => ({
           ...activity,
           timestamp:
             activity.timestamp instanceof Date

--- a/components/dispatch/dispatch-header.tsx
+++ b/components/dispatch/dispatch-header.tsx
@@ -6,7 +6,6 @@ import { Activity, RadioTower, RefreshCw, WifiOff } from "lucide-react";
 
 interface DispatchHeaderProps {
   orgId: string;
-  userId: string;
 }
 
 export default function DispatchHeader({ orgId }: DispatchHeaderProps) {

--- a/components/dispatch/recent-activity.tsx
+++ b/components/dispatch/recent-activity.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { Activity as ActivityIcon, Clock } from "lucide-react";
 import {
   Card,
@@ -11,6 +9,15 @@ import {
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 
+interface ActivityItem {
+  id: string | number;
+  userName: string;
+  timestamp: string;
+  action: string;
+  entityType: string;
+  entityId: string;
+}
+
 interface RecentActivityProps {
   params: { userId: string };
   stats: {
@@ -20,25 +27,18 @@ interface RecentActivityProps {
     inTransitLoads: number;
     completedLoads: number;
   };
-  RecentActivity: Array<{
-    id: string | number;
-    userName: string;
-    timestamp: string;
-    action: string;
-    entityType: string;
-    entityId: string;
-  }>;
+  activities: ActivityItem[];
 }
 
 export function RecentActivityRow({
   params,
   stats,
-  RecentActivity,
+  activities,
 }: RecentActivityProps) {
-  const formatLabel = (item: any) =>
+  const formatLabel = (item: ActivityItem) =>
     `${item.userName} ${item.action.toLowerCase()} ${item.entityType.toLowerCase()} ${item.entityId}`;
 
-  const [first, ...rest] = RecentActivity;
+  const [first, ...rest] = activities;
 
   return (
     <Card className="bg-black border border-gray-200">

--- a/features/dispatch/DispatchBoardFeature.tsx
+++ b/features/dispatch/DispatchBoardFeature.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useTransition } from "react";
-import type { Load } from "@/types/dispatch";
+import type { Load, LoadStatus } from "@/types/dispatch";
 import type { Driver } from "@/types/drivers";
 import type { Vehicle } from "@/types/vehicles";
 import { DispatchBoardUI } from "@/components/dispatch/dispatch-board";
 import { useRouter } from "next/navigation";
+import { updateLoadStatusAction } from "@/lib/actions/dispatchActions";
 
 interface DispatchBoardFeatureProps {
   loads: Load[];
@@ -98,13 +99,9 @@ export function DispatchBoardFeature({ loads, drivers, vehicles, orgId, searchPa
     router.push(`/${orgId}/loads/${load.id}`);
   };
 
-  const onStatusUpdate = async (loadId: string, newStatus: string) => {
+  const onStatusUpdate = async (loadId: string, newStatus: LoadStatus) => {
     startTransition(async () => {
-      await fetch(`/api/loads/${loadId}/status`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ status: newStatus })
-      });
+      await updateLoadStatusAction(orgId, loadId, newStatus);
       router.refresh();
     });
   };

--- a/lib/fetchers/dispatchFetchers.ts
+++ b/lib/fetchers/dispatchFetchers.ts
@@ -153,5 +153,8 @@ export async function getRecentDispatchActivity(orgId: string, limit = 5) {
     orderBy: { timestamp: "desc" },
     take: limit,
   });
-  return { success: true, data: activities };
+
+  const unique = Array.from(new Map(activities.map(a => [a.id, a])).values());
+
+  return { success: true, data: unique };
 }


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: dispatch
Milestone: Core

## Description
Improves the dispatch board by deduplicating recent activity entries, shifting the recent activity component to a server component, removing an unused prop from the header, and replacing client fetches with a typed server action for status updates.

## Related Issue
Closes #38 - Dispatch Enhancement: Resolve board header/activity issues (Core)

## Wave Dependencies
- Builds on: existing dispatch board feature
- Enables: cleaner server/client separation for future work

## Domain Impact
- Primary domain: dispatch
- Files modified: main dispatch feature components and fetchers
- Integration points: server actions used for status updates

## Milestone Compliance
- [x] Meets Core complexity requirements
- [x] Aligns with milestone delivery goals
- [x] No scope creep beyond milestone definition

## Wave Completion
- [x] Domain task completed for current wave
- [x] Dependencies resolved or properly managed
- [x] Ready for wave progression

## Testing Performed
- [x] `npm test` *(fails: multiple suites)*
- [x] `npx tsc --noEmit` *(fails in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6888ede007108327b67d24d17c9bee22