### PR TITLE
Tenant feat: unify page headers

### DIFF
--- a/app/(tenant)/[orgId]/analytics/page.tsx
+++ b/app/(tenant)/[orgId]/analytics/page.tsx
@@ -1,4 +1,4 @@
-import { BarChart3, DollarSign, Filter, MapPin, TrendingUp, Truck, User } from 'lucide-react';
+import { BarChart2, DollarSign, Filter, MapPin, TrendingUp, Truck, User } from 'lucide-react';
 
 import { DriverPerformance } from '@/components/analytics/driver-performance';
 import { ExportOptions } from '@/components/analytics/export-options';
@@ -181,14 +181,17 @@ export default async function AnalyticsPage({ params, searchParams }: AnalyticsP
           timeRange={timeRange}
         />
       </div>
-      <div className="mb-2 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-        <div>
-          <h1 className="mb-1 text-3xl font-extrabold text-white">Analytics Dashboard</h1>
-          <p className="text-base text-white/90">
+      <div className="flex flex-row items-baseline justify-between mb-6">
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-3">
+            <BarChart2 className="h-8 w-8 text-white" />
+            <h1 className="text-3xl font-extrabold text-white">Analytics Dashboard</h1>
+          </div>
+          <p className="text-base text-white/90 font-medium">
             Track and analyze fleet performance metrics with advanced insights
           </p>
-        </div>{' '}
-        <div className="mt-4 flex flex-col gap-2 md:mt-0 md:flex-row">
+        </div>
+        <div className="flex flex-col gap-2 md:flex-row">
           <ExportOptions
             orgId={orgId}
             filters={filters}

--- a/app/(tenant)/[orgId]/compliance/page.tsx
+++ b/app/(tenant)/[orgId]/compliance/page.tsx
@@ -1,4 +1,4 @@
-  import { Suspense } from 'react';
+import { Suspense } from 'react';
 import {
   CalendarIcon,
   ClipboardCheck,
@@ -11,13 +11,7 @@ import {
 } from 'lucide-react';
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { DriverComplianceTable } from '@/components/compliance/driver-compliance-table';
 import { VehicleComplianceTable } from '@/components/compliance/vehicle-compliance-table';
@@ -29,12 +23,12 @@ import { getComplianceDashboard } from '@/lib/fetchers/complianceFetchers';
 import { PageLayout } from '@/components/shared/PageLayout';
 
 interface CompliancePageProps {
-  params: Promise<{ orgId: string }>
+  params: Promise<{ orgId: string }>;
 }
 
 export default async function CompliancePage({ params }: CompliancePageProps) {
   const { orgId } = await params;
-    // Fetch dashboard data with error handling
+  // Fetch dashboard data with error handling
   let dashboardData: any = {};
   try {
     dashboardData = await getComplianceDashboard(orgId);
@@ -54,24 +48,25 @@ export default async function CompliancePage({ params }: CompliancePageProps) {
     };
   }
 
-  const hasData = dashboardData && typeof dashboardData === 'object' && dashboardData.totalDocuments !== undefined;
-  
+  const hasData =
+    dashboardData &&
+    typeof dashboardData === 'object' &&
+    dashboardData.totalDocuments !== undefined;
+
   return (
     <PageLayout className="compliance-page p-4 md:p-6">
-      <div className="mt-14 mb-2 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-        <div>
-          <h1 className="page-title">Compliance Management</h1>
-          <p className="page-subtitle">
-            Monitor and manage regulatory compliance for your fleet, drivers,
-            and documents.
+      <div className="flex flex-row items-baseline justify-between mb-6">
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-3">
+            <FileText className="h-8 w-8 text-white" />
+            <h1 className="text-3xl font-extrabold text-white">Compliance Management</h1>
+          </div>
+          <p className="text-sm text-white/90 font-medium">
+            Monitor and manage regulatory compliance for your fleet, drivers, and documents.
           </p>
         </div>
-        <div className="mr-6 flex w-full flex-col gap-4 md:w-auto">
-          <Button
-            variant="outline"
-            size="sm"
-            className="btn btn-outline w-full md:w-auto"
-          >
+        <div className="flex w-full flex-col gap-4 md:w-auto">
+          <Button variant="outline" size="sm" className="btn btn-outline w-full md:w-auto">
             <Eye className="mr-2 h-4 w-4" />
             Schedule Audit
           </Button>
@@ -80,7 +75,8 @@ export default async function CompliancePage({ params }: CompliancePageProps) {
             Generate Report
           </Button>
         </div>
-        {/* Enhanced Dashboard with Real Data */}
+      </div>
+      {/* Enhanced Dashboard with Real Data */}
       <Suspense fallback={<div>Loading compliance dashboard...</div>}>
         <ComplianceDashboard orgId={orgId} />
       </Suspense>
@@ -94,99 +90,85 @@ export default async function CompliancePage({ params }: CompliancePageProps) {
           <TabsTrigger value="inspections">DOT</TabsTrigger>
           <TabsTrigger value="alerts">Alerts</TabsTrigger>
         </TabsList>
-        
+
         <TabsContent value="overview" className="mt-4">
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
             <Card className="card">
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                <CardTitle className="text-sm font-medium">
-                  Driver Compliance
-                </CardTitle>
+                <CardTitle className="text-sm font-medium">Driver Compliance</CardTitle>
                 <UserIcon className="h-4 w-4 text--info" />
               </CardHeader>
               <CardContent className="p-6 space-y-6">
                 <div className="card-metric">
-                  {hasData && dashboardData.totalDrivers > 0 ? 
-                    `${Math.round((dashboardData.driversInCompliance / dashboardData.totalDrivers) * 100)}%` 
-                    : '0%'
-                  }
+                  {hasData && dashboardData.totalDrivers > 0
+                    ? `${Math.round((dashboardData.driversInCompliance / dashboardData.totalDrivers) * 100)}%`
+                    : '0%'}
                 </div>
                 <p className="text-xs text-success">
-                  {hasData ? 
-                    `${dashboardData.driversInCompliance} of ${dashboardData.totalDrivers} drivers compliant` 
-                    : 'No data available'
-                  }
+                  {hasData
+                    ? `${dashboardData.driversInCompliance} of ${dashboardData.totalDrivers} drivers compliant`
+                    : 'No data available'}
                 </p>
               </CardContent>
             </Card>
             <Card className="card">
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                <CardTitle className="text-sm font-medium">
-                  Vehicle Compliance
-                </CardTitle>
+                <CardTitle className="text-sm font-medium">Vehicle Compliance</CardTitle>
                 <TruckIcon className="h-4 w-4 text-info" />
               </CardHeader>
               <CardContent className="p-6 space-y-6">
                 <div className="card-metric">
-                  {hasData && dashboardData.totalVehicles > 0 ? 
-                    `${Math.round((dashboardData.vehiclesInCompliance / dashboardData.totalVehicles) * 100)}%` 
-                    : '0%'
-                  }
+                  {hasData && dashboardData.totalVehicles > 0
+                    ? `${Math.round((dashboardData.vehiclesInCompliance / dashboardData.totalVehicles) * 100)}%`
+                    : '0%'}
                 </div>
                 <p className="text-xs text-success">
-                  {hasData ? 
-                    `${dashboardData.vehiclesInCompliance} of ${dashboardData.totalVehicles} vehicles compliant` 
-                    : 'No data available'
-                  }
+                  {hasData
+                    ? `${dashboardData.vehiclesInCompliance} of ${dashboardData.totalVehicles} vehicles compliant`
+                    : 'No data available'}
                 </p>
               </CardContent>
             </Card>
             <Card className="card">
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                <CardTitle className="text-sm font-medium">
-                  Active Violations
-                </CardTitle>
+                <CardTitle className="text-sm font-medium">Active Violations</CardTitle>
                 <AlertTriangle className="h-4 w-4 text-warning" />
               </CardHeader>
               <CardContent className="p-6 space-y-6">
                 <div className="card-metric">
-                  {hasData ? (dashboardData.activeViolations || 0) : 0}
+                  {hasData ? dashboardData.activeViolations || 0 : 0}
                 </div>
                 <p className="text-xs text-danger">Requires attention</p>
               </CardContent>
             </Card>
             <Card className="card">
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                <CardTitle className="text-sm font-medium">
-                  Document Status
-                </CardTitle>
+                <CardTitle className="text-sm font-medium">Document Status</CardTitle>
                 <FileText className="h-4 w-4 text-info" />
               </CardHeader>
               <CardContent className="p-6 space-y-6">
                 <div className="card-metric">
-                  {hasData && dashboardData.totalDocuments > 0 ? 
-                    `${Math.round(((dashboardData.totalDocuments - dashboardData.expiredDocuments) / dashboardData.totalDocuments) * 100)}%` 
-                    : '0%'
-                  }
+                  {hasData && dashboardData.totalDocuments > 0
+                    ? `${Math.round(((dashboardData.totalDocuments - dashboardData.expiredDocuments) / dashboardData.totalDocuments) * 100)}%`
+                    : '0%'}
                 </div>
                 <p className="text-xs text-success">
-                  {hasData ? 
-                    `${dashboardData.totalDocuments - dashboardData.expiredDocuments} of ${dashboardData.totalDocuments} current` 
-                    : 'No documents'
-                  }
+                  {hasData
+                    ? `${dashboardData.totalDocuments - dashboardData.expiredDocuments} of ${dashboardData.totalDocuments} current`
+                    : 'No documents'}
                 </p>
               </CardContent>
             </Card>
           </div>
         </TabsContent>
-        
+
         <TabsContent value="drivers" className="mt-4">
           <Card className="card">
             <CardHeader>
               <CardTitle>Driver Compliance Status</CardTitle>
               <CardDescription>
-                Monitor driver compliance with regulations including HOS,
-                licenses, and medical certifications.
+                Monitor driver compliance with regulations including HOS, licenses, and medical
+                certifications.
               </CardDescription>
             </CardHeader>
             <CardContent className="overflow-x-auto">
@@ -196,26 +178,23 @@ export default async function CompliancePage({ params }: CompliancePageProps) {
             </CardContent>
           </Card>
         </TabsContent>
-        
+
         <TabsContent value="vehicles" className="mt-4">
           <Card className="card">
             <CardHeader>
               <CardTitle>Vehicle Compliance Status</CardTitle>
               <CardDescription>
-                Track vehicle inspections, maintenance, and registration
-                compliance.
+                Track vehicle inspections, maintenance, and registration compliance.
               </CardDescription>
             </CardHeader>
             <CardContent className="overflow-x-auto">
-              <Suspense
-                fallback={<div>Loading vehicle compliance data...</div>}
-              >
+              <Suspense fallback={<div>Loading vehicle compliance data...</div>}>
                 <VehicleComplianceTable orgId={orgId} />
               </Suspense>
             </CardContent>
           </Card>
         </TabsContent>
-        
+
         <TabsContent value="documents" className="mt-4">
           <Card className="card">
             <CardHeader>
@@ -231,7 +210,7 @@ export default async function CompliancePage({ params }: CompliancePageProps) {
             </CardContent>
           </Card>
         </TabsContent>
-        
+
         <TabsContent value="inspections" className="mt-4">
           <Card className="card">
             <CardHeader>
@@ -247,7 +226,7 @@ export default async function CompliancePage({ params }: CompliancePageProps) {
             </CardContent>
           </Card>
         </TabsContent>
-        
+
         <TabsContent value="alerts" className="mt-4">
           <Card className="card">
             <CardHeader>

--- a/app/(tenant)/[orgId]/ifta/page.tsx
+++ b/app/(tenant)/[orgId]/ifta/page.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from 'react';
-import { BarChart3, CalendarIcon, FileText, MapPin } from 'lucide-react';
+import { Activity, BarChart3, CalendarIcon, FileText, MapPin } from 'lucide-react';
 import type { IFTAReport } from '@/components/ifta/ifta-columns';
 import { IftaReportTableClient, IftaTripTableClient } from '@/components/ifta/ifta-tables';
 import { Button } from '@/components/ui/button';
@@ -81,20 +81,20 @@ export default async function Page({ params }: { params: Promise<{ orgId: string
   return (
     <div className="min-h-screen space-y-6 bg-neutral-900 p-6 pt-8">
       {/* Header Section */}
-      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-        <div className="space-y-2">
-          <div className="flex items-center gap-2">
-            <BarChart3 className="h-8 w-8 text-blue-500" />
-            <h1 className="text-3xl font-bold text-white">IFTA Management</h1>
+      <div className="flex flex-row items-baseline justify-between mb-6">
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-3">
+            <Activity className="h-8 w-8 text-white" />
+            <h1 className="text-3xl font-extrabold text-white">IFTA Management</h1>
             <span className="border border-blue-200 bg-blue-50 text-blue-700 rounded px-2 py-1 text-xs font-semibold">
               Compliance
             </span>
           </div>
-          <p className="text-gray-400">
+          <p className="text-gray-400 font-medium">
             Track and manage International Fuel Tax Agreement reporting
           </p>
         </div>
-        <div className="flex flex-row gap-4 mt-4 md:mt-0">
+        <div className="flex flex-row gap-4">
           <Button
             size="sm"
             className="rounded-md bg-blue-500 px-6 py-2 font-semibold text-white hover:bg-blue-800 flex items-center gap-2"

--- a/app/(tenant)/[orgId]/vehicles/page.tsx
+++ b/app/(tenant)/[orgId]/vehicles/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react';
 import { listVehiclesByOrg } from '@/lib/fetchers/vehicleFetchers';
-import { Plus } from 'lucide-react';
+import { Plus, Truck } from 'lucide-react';
 import Link from 'next/link';
 import VehiclesClient from './vehicles-client';
 import { VehicleListSkeleton } from '@/components/vehicles/vehicle-list-skeleton';
@@ -16,10 +16,15 @@ export default async function VehiclesPage({ params }: VehiclesPageProps) {
   return (
     <div className="flex flex-col gap-6 p-6 bg-neutral-900 text-white min-h-screen">
       {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold tracking-tight text-white">Fleet Vehicles</h1>
-          <p className="text-white/70">Manage your fleet vehicles and their information</p>
+      <div className="flex flex-row items-baseline justify-between mb-6">
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-3">
+            <Truck className="h-8 w-8 text-white" />
+            <h1 className="text-3xl font-extrabold text-white">Fleet Vehicles</h1>
+          </div>
+          <p className="text-white/90 font-medium">
+            Manage your fleet vehicles and their information
+          </p>
         </div>
         <Link href={`/${orgId}/vehicles/new`}>
           <button className="rounded-md bg-blue-500 px-6 py-2 font-semibold text-white hover:bg-blue-800 inline-flex items-center gap-2">

--- a/components/dashboard/fleet-overview-header.tsx
+++ b/components/dashboard/fleet-overview-header.tsx
@@ -1,7 +1,7 @@
 import { Card, CardContent } from '@/components/ui/card';
 import { getDashboardSummary } from '@/lib/fetchers/analyticsFetchers';
 import type { DashboardSummary } from '@/types/dashboard';
-import { RefreshCw, Shield } from 'lucide-react';
+import { RefreshCw, Home } from 'lucide-react';
 
 interface FleetOverviewHeaderProps {
   orgId: string;
@@ -48,7 +48,7 @@ export default async function FleetOverviewHeader({ orgId }: FleetOverviewHeader
     <div className="flex flex-row items-baseline justify-between mb-6">
       <div className="flex flex-col gap-2">
         <div className="flex items-center gap-3">
-          <Shield className="h-8 w-8" />
+          <Home className="h-8 w-8 text-white" />
           <h1 className="text-3xl font-extrabold text-white">Admin Dashboard</h1>
           <div className="flex items-center gap-2 bg-green-500/20 rounded-full px-3 py-1">
             <div className="w-2 h-2 bg-green-400 rounded-full animate-pulse"></div>

--- a/components/dispatch/dispatch-header.tsx
+++ b/components/dispatch/dispatch-header.tsx
@@ -2,7 +2,7 @@
 
 import { Card, CardContent } from '@/components/ui/card';
 import { useDispatchRealtime } from '@/hooks/use-dispatch-realtime';
-import { Activity, RadioTower, RefreshCw, WifiOff } from 'lucide-react';
+import { Activity, ClipboardList, RefreshCw, WifiOff } from 'lucide-react';
 
 interface DispatchHeaderProps {
   orgId: string;
@@ -38,7 +38,7 @@ export default function DispatchHeader({ orgId }: DispatchHeaderProps) {
     <div className="flex flex-row items-baseline justify-between mb-6">
       <div className="flex flex-col gap-2">
         <div className="flex items-center gap-3">
-          <RadioTower className="h-8 w-8 text-white" />
+          <ClipboardList className="h-8 w-8 text-white" />
           <h1 className="text-3xl font-extrabold text-white">Dispatch Dashboard</h1>
           <div className="flex items-center gap-2 bg-green-500/20 rounded-full px-3 py-1">
             {isConnected ? (

--- a/components/drivers/drivers-list-header.tsx
+++ b/components/drivers/drivers-list-header.tsx
@@ -2,7 +2,7 @@
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { Button } from '../ui/button';
-import { Plus, RefreshCw } from 'lucide-react';
+import { Plus, RefreshCw, Users } from 'lucide-react';
 
 export default function DriversListHeader() {
   const params = useParams();
@@ -25,37 +25,35 @@ export default function DriversListHeader() {
   }
 
   return (
-    <div className="mb-6">
-      {/* Header */}
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex flex-col gap-3">
-          <div className="flex items-center gap-3">
-            <h1 className="text-3xl font-extrabold text-white">Driver Management</h1>
-            <div className="flex items-center gap-2 bg-green-500/20 rounded-full px-3 py-1">
-              <div className="w-2 h-2 bg-green-400 rounded-full animate-pulse"></div>
-              <span className="text-green-400 text-sm font-medium">Live</span>
-            </div>
-          </div>
-          <h2 className="text-sm text-white/90 mb-2">
-            Manage your fleet drivers with compliance tracking and performance monitoring
-          </h2>
-          <div className="flex items-center space-x-2 text-sm text-white/70">
-            <RefreshCw className="h-3 w-3" />
-            <span>Last updated: {lastUpdated || '2 minutes ago'}</span>
+    <div className="flex flex-row items-baseline justify-between mb-6">
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-3">
+          <Users className="h-8 w-8 text-white" />
+          <h1 className="text-3xl font-extrabold text-white">Driver Management</h1>
+          <div className="flex items-center gap-2 bg-green-500/20 rounded-full px-3 py-1">
+            <div className="w-2 h-2 bg-green-400 rounded-full animate-pulse"></div>
+            <span className="text-green-400 text-sm font-medium">Live</span>
           </div>
         </div>
-        <div className="flex items-center gap-2">
-          <Button
-            asChild
-            size="sm"
-            className="rounded-md bg-blue-500 px-6 py-2 font-semibold text-white hover:bg-blue-800"
-          >
-            <Link href={`/${orgId}/drivers/new`}>
-              <Plus className="mr-2 h-4 w-4" />
-              Add Driver
-            </Link>
-          </Button>
+        <h2 className="text-sm text-white/90 font-medium">
+          Manage your fleet drivers with compliance tracking and performance monitoring
+        </h2>
+        <div className="flex items-center space-x-2 text-sm text-white/70">
+          <RefreshCw className="h-3 w-3" />
+          <span>Last updated: {lastUpdated || '2 minutes ago'}</span>
         </div>
+      </div>
+      <div className="flex items-center gap-2">
+        <Button
+          asChild
+          size="sm"
+          className="rounded-md bg-blue-500 px-6 py-2 font-semibold text-white hover:bg-blue-800"
+        >
+          <Link href={`/${orgId}/drivers/new`}>
+            <Plus className="mr-2 h-4 w-4" />
+            Add Driver
+          </Link>
+        </Button>
       </div>
     </div>
   );

--- a/components/settings/settings-dashboard.tsx
+++ b/components/settings/settings-dashboard.tsx
@@ -125,19 +125,21 @@ export function SettingsDashboard({
   return (
     <div className="min-h-screen space-y-6 bg-neutral-900 p-6 pt-8">
       {/* Header Section */}
-      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-        <div className="space-y-2">
-          <div className="flex items-center gap-2">
-            <Settings className="h-8 w-8 text-blue-500" />
-            <h1 className="text-3xl font-bold text-white">Settings Management</h1>
+      <div className="flex flex-row items-baseline justify-between mb-6">
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-3">
+            <Settings className="h-8 w-8 text-white" />
+            <h1 className="text-3xl font-extrabold text-white">Settings Management</h1>
             <span className="border border-blue-200 bg-blue-50 text-blue-700 rounded px-2 py-1 text-xs font-semibold">
               Admin
             </span>
           </div>
-          <p className="text-gray-400">Export, import, and manage your organization settings</p>
+          <p className="text-gray-400 font-medium">
+            Export, import, and manage your organization settings
+          </p>
         </div>
         {accessibleTabs.includes('organization') && (
-          <div className="flex flex-row gap-4 mt-4 md:mt-0">
+          <div className="flex flex-row gap-4">
             <Button
               variant="outline"
               size="sm"


### PR DESCRIPTION
## Summary
- standardize header styles across tenant pages
- use matching sidebar icons with white w-8 h-8 styling

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68893678b0708327a8ef989b6fbd328a