### PR TITLE
[Dispatch] fix: Map load relations for card (Core) (Closes #38)

### DIFF
--- a/components/dispatch/load-card.tsx
+++ b/components/dispatch/load-card.tsx
@@ -30,7 +30,7 @@ interface LoadCardProps {
   isUpdating?: boolean;
 }
 
-export function LoadCard({ load, onStatusUpdate, isUpdating }: LoadCardProps) {
+export function LoadCard({ load, onClick, onStatusUpdate, isUpdating }: LoadCardProps) {
   const getStatusColor = (status: string) => {
     switch (status) {
       case 'assigned':
@@ -67,7 +67,10 @@ export function LoadCard({ load, onStatusUpdate, isUpdating }: LoadCardProps) {
   };
 
   return (
-    <Card className="bg-card text-card-foreground border border-border">
+    <Card
+      onClick={onClick}
+      className="bg-card text-card-foreground border border-border cursor-pointer"
+    >
       <CardHeader className="pb-2">
         <div className="flex items-start justify-between">
           <CardTitle className="text-lg">{load.referenceNumber}</CardTitle>

--- a/lib/utils/transformers.ts
+++ b/lib/utils/transformers.ts
@@ -83,9 +83,13 @@ export function transformLoad(raw: any): Load | null {
     pickupDate: raw.scheduledPickupDate ?? raw.actualPickupDate ?? new Date(),
     deliveryDate: raw.scheduledDeliveryDate ?? raw.actualDeliveryDate ?? new Date(),
     equipment: raw.equipment || {},
-    driver: raw.drivers ?? raw.driver ?? null,
+    driver: raw.drivers
+      ? transformDriver(raw.drivers)
+      : raw.driver
+        ? transformDriver(raw.driver)
+        : null,
     driverId: raw.driver_id ?? raw.driverId ?? null,
-    vehicle: raw.vehicle,
+    vehicle: raw.vehicle ? transformVehicle(raw.vehicle) : undefined,
     vehicleId: raw.vehicleId || null,
     cargo: raw.cargo || {},
     rate: raw.rate || {},


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: dispatch
Milestone: Core

## Description
Align load card with dispatch types and ensure relational data from Prisma is mapped correctly. `transformLoad` now transforms associated driver and vehicle records using existing helpers. Load cards accept a click handler and render as clickable cards.

## Related Issue
Closes #38 - Dispatch fix: ensure load card data maps correctly (Core)

## Wave Dependencies
- Builds on: none
- Enables: future dispatch UI refinements
- Cross-domain integration: none

## Domain Impact
- Primary domain: dispatch
- Files modified: `components/dispatch/load-card.tsx`, `lib/utils/transformers.ts`
- Integration points: load fetching utilities

## Milestone Compliance
- [ ] Meets Core complexity requirements
- [ ] Aligns with milestone delivery goals
- [ ] No scope creep beyond milestone definition

## Wave Completion
- [ ] Domain task completed for current wave
- [ ] Dependencies resolved or properly managed
- [ ] Ready for wave progression

## Testing Performed
- [ ] Domain-specific functionality verified
- [ ] Cross-domain integrations tested
- [ ] Wave dependencies validated
- [ ] Milestone requirements met


------
https://chatgpt.com/codex/tasks/task_e_6889442a642883278cccefdebb3ec004