### PR TITLE
[Dispatch] fix: improve updates API responses (MVP) (Closes #38)

### DIFF
--- a/app/api/dispatch/[orgId]/updates/route.ts
+++ b/app/api/dispatch/[orgId]/updates/route.ts
@@ -1,17 +1,28 @@
 import { auth } from '@clerk/nextjs/server';
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
 import db from '@/lib/database/db';
 
-export async function GET({ params }: { params: Promise<{ orgId: string }> }) {
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ orgId: string }> },
+) {
   const { orgId } = await params;
   const { userId } = await auth();
+  const headers = { 'Cache-Control': 'no-store' } as const;
   if (!userId) {
-    return { error: 'Unauthorized' };
+    return NextResponse.json(
+      { error: 'Unauthorized' },
+      { status: 401, headers },
+    );
   }
 
   try {
+    const since = request.nextUrl.searchParams.get('since');
     const events = await db.loadStatusEvent.findMany({
       where: {
         load: { organizationId: orgId },
+        ...(since ? { timestamp: { gt: new Date(since) } } : {}),
       },
       orderBy: { timestamp: 'asc' },
       take: 20,
@@ -41,8 +52,11 @@ export async function GET({ params }: { params: Promise<{ orgId: string }> }) {
       },
     }));
 
-    return { updates };
+    return NextResponse.json({ updates }, { headers });
   } catch (error) {
-    return { error: 'Failed to fetch updates' };
+    return NextResponse.json(
+      { error: 'Failed to fetch updates' },
+      { status: 500, headers },
+    );
   }
 }

--- a/hooks/use-dispatch-realtime.ts
+++ b/hooks/use-dispatch-realtime.ts
@@ -174,11 +174,11 @@ export function useDispatchRealtime({
           },
         );
 
+        const data = await response.json().catch(() => null);
+
         if (response.ok) {
-          const data = await response.json();
-          if (data.updates && data.updates.length > 0) {
+          if (data?.updates && data.updates.length > 0) {
             data.updates.forEach((update: DispatchUpdate) => {
-              // Safely extract timestamp
               const timestamp = update.data?.timestamp || update.timestamp;
               if (timestamp) {
                 lastSeenLoadTimestamp.current = timestamp;
@@ -188,6 +188,9 @@ export function useDispatchRealtime({
           }
           setIsConnected(true);
         } else {
+          if (data?.error) {
+            console.error('Polling error:', data.error);
+          }
           setIsConnected(false);
         }
       } catch (error) {


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: dispatch
Milestone: MVP

## Description
Updated the dispatch updates API to return `NextResponse` with proper HTTP
status codes and cache-control headers. Client polling logic was updated to
handle new response semantics.

## Related Issue
Closes #38 - Dispatch fix: updates endpoint should use NextResponse (MVP)

## Wave Dependencies
- Builds on: none
- Enables: future dispatch realtime enhancements
- Cross-domain integration: none

## Domain Impact
- Primary domain: dispatch
- Files modified:
  - app/api/dispatch/[orgId]/updates/route.ts
  - hooks/use-dispatch-realtime.ts
- Integration points: client polling of dispatch updates

## Milestone Compliance
- [x] Meets MVP complexity requirements
- [x] Aligns with milestone delivery goals
- [x] No scope creep beyond milestone definition

## Wave Completion
- [x] Domain task completed for current wave
- [x] Dependencies resolved or properly managed
- [x] Ready for wave progression

## Testing Performed
- [ ] Domain-specific functionality verified
- [ ] Cross-domain integrations tested
- [ ] Wave dependencies validated
- [ ] Milestone requirements met

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6889709486a883279e8685ea5d81d401