### PR TITLE
[Dispatch] feat: validate load status transitions (Core) (Closes #38)

### DIFF
--- a/lib/utils/dispatchStatus.ts
+++ b/lib/utils/dispatchStatus.ts
@@ -1,0 +1,23 @@
+import type { LoadStatus } from '@/types/dispatch';
+
+export const allowedStatusTransitions: Record<LoadStatus, LoadStatus[]> = {
+  draft: ['pending'],
+  pending: ['assigned', 'cancelled'],
+  posted: ['booked'],
+  booked: ['confirmed'],
+  confirmed: ['dispatched'],
+  dispatched: ['at_pickup'],
+  at_pickup: ['picked_up'],
+  picked_up: ['en_route'],
+  en_route: ['at_delivery'],
+  at_delivery: ['delivered'],
+  assigned: ['in_transit', 'cancelled'],
+  in_transit: ['delivered', 'cancelled'],
+  delivered: ['completed'],
+  pod_required: ['completed'],
+  completed: [],
+  invoiced: ['paid'],
+  paid: [],
+  cancelled: [],
+  problem: [],
+};

--- a/tests/domains/dispatch/updateLoadStatusAction.test.ts
+++ b/tests/domains/dispatch/updateLoadStatusAction.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }));
+vi.mock('@clerk/nextjs/server', () => ({ auth: () => Promise.resolve({ userId: 'u1' }) }));
+
+const dbMock = {
+  load: {
+    findUnique: vi.fn(),
+    update: vi.fn().mockResolvedValue({ id: 'l1' }),
+  },
+  loadStatusEvent: { create: vi.fn() },
+  dispatchActivity: { create: vi.fn() },
+};
+
+vi.mock('../../../lib/database/db', () => ({ __esModule: true, default: dbMock }));
+vi.mock('../../../lib/errors/handleError', () => ({ handleError: vi.fn() }));
+
+describe('updateLoadStatusAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('updates status when transition is allowed', async () => {
+    dbMock.load.findUnique.mockResolvedValue({ status: 'assigned' });
+    const { updateLoadStatusAction } = await import('../../../lib/actions/dispatchActions');
+    const res = await updateLoadStatusAction('org1', 'l1', 'in_transit');
+    expect(res.success).toBe(true);
+    expect(dbMock.load.update).toHaveBeenCalled();
+    expect(dbMock.loadStatusEvent.create).toHaveBeenCalled();
+  });
+
+  it('returns error for invalid transition', async () => {
+    dbMock.load.findUnique.mockResolvedValue({ status: 'assigned' });
+    const { updateLoadStatusAction } = await import('../../../lib/actions/dispatchActions');
+    const res = await updateLoadStatusAction('org1', 'l1', 'delivered');
+    expect(res).toEqual({ success: false, error: 'Invalid status change' });
+    expect(dbMock.load.update).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: dispatch
Milestone: Core

## Description
Adds server-side validation for load status updates to ensure transitions follow defined rules. Introduces `allowedStatusTransitions` utility and verifies requested changes against current status before persisting.

## Related Issue
Closes #38 - Dispatch Feat: Validate load status transitions (Core)

## Wave Dependencies
- Builds on: none
- Enables: future status management tasks
- Cross-domain integration: none

## Domain Impact
- Primary domain: dispatch
- Files modified: `lib/actions/dispatchActions.ts`, `lib/utils/dispatchStatus.ts`, `tests/domains/dispatch/updateLoadStatusAction.test.ts`
- Integration points: none

## Milestone Compliance
- [x] Meets Core complexity requirements
- [x] Aligns with milestone delivery goals
- [x] No scope creep beyond milestone definition

## Wave Completion
- [x] Domain task completed for current wave
- [x] Dependencies resolved or properly managed
- [x] Ready for wave progression

## Testing Performed
- [x] `npx vitest run tests/domains/dispatch/updateLoadStatusAction.test.ts`
- [ ] `npm test` *(fails: other suites fail to run)*
- [ ] `npm run lint` *(fails: ESLint config missing)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_688970960ebc83279af85adcce210853