### PR TITLE
[Dispatch] feat: implement load document uploads (Core) (Closes #38)

### DIFF
--- a/components/dispatch/load-details-dialog.tsx
+++ b/components/dispatch/load-details-dialog.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { updateDispatchLoadAction } from '@/lib/actions/dispatchActions';
+import { LoadDocuments } from './load-documents';
 import type { Driver } from '@/types/drivers';
 import type { Load } from '@/types/dispatch';
 import type { Vehicle } from '@/types/vehicles';
@@ -258,25 +259,7 @@ export function LoadDetailsDialog({
 
           {/* Documents Tab */}
           <TabsContent value="documents" className="mt-4">
-            {load.documents && load.documents.length > 0 ? (
-              <ul className="list-disc pl-6 text-sm">
-                {load.documents.map((doc) => (
-                  <li key={doc.id}>
-                    {doc.type?.toUpperCase()}:{' '}
-                    <a
-                      href={doc.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="underline"
-                    >
-                      {doc.name}
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            ) : (
-              <p className="text-sm text-gray-400">No documents uploaded.</p>
-            )}
+            <LoadDocuments orgId={orgId} loadId={load.id} />
           </TabsContent>
 
           {/* History Tab */}

--- a/components/dispatch/load-document-list.tsx
+++ b/components/dispatch/load-document-list.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useTransition } from 'react';
+import { Trash2 } from 'lucide-react';
+import type { Document } from '@/types/dispatch';
+import { Button } from '@/components/ui/button';
+import { deleteLoadDocument } from '@/lib/actions/documentActions';
+
+interface LoadDocumentListProps {
+  orgId: string;
+  documents: Document[];
+  refresh: () => void;
+}
+
+export function LoadDocumentList({ orgId, documents, refresh }: LoadDocumentListProps) {
+  const [isPending, start] = useTransition();
+
+  const handleDelete = (id: string) => {
+    start(async () => {
+      await deleteLoadDocument(orgId, id);
+      refresh();
+    });
+  };
+
+  if (documents.length === 0) {
+    return <p className="text-sm text-gray-400">No documents uploaded.</p>;
+  }
+
+  return (
+    <ul className="space-y-2">
+      {documents.map((doc) => (
+        <li key={doc.id} className="flex items-center justify-between rounded border p-2">
+          <a href={doc.url} target="_blank" rel="noopener noreferrer" className="underline">
+            {doc.name}
+          </a>
+          <Button size="icon" variant="ghost" onClick={() => handleDelete(doc.id)} disabled={isPending}>
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/components/dispatch/load-document-upload-form.tsx
+++ b/components/dispatch/load-document-upload-form.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { put } from '@vercel/blob/client';
+import { Button } from '@/components/ui/button';
+import { getSignedUploadToken } from '@/lib/actions/fileUploadActions';
+import { saveLoadDocument } from '@/lib/actions/documentActions';
+import type { Document } from '@/types/dispatch';
+
+interface LoadDocumentUploadFormProps {
+  orgId: string;
+  loadId: string;
+  onUploaded: (doc: Document) => void;
+}
+
+export function LoadDocumentUploadForm({ orgId, loadId, onUploaded }: LoadDocumentUploadFormProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+
+  async function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setError(null);
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (file.size > 10 * 1024 * 1024) {
+      setError('File too large (max 10MB)');
+      return;
+    }
+
+    setUploading(true);
+    try {
+      const tokenRes = await getSignedUploadToken(file.name);
+      if (!tokenRes.success || !('token' in tokenRes) || !tokenRes.token) {
+        const msg = 'error' in tokenRes && tokenRes.error ? tokenRes.error : 'Failed to get upload token';
+        setError(msg);
+        return;
+      }
+      const { token, pathname } = tokenRes as { token: string; pathname: string; success: true };
+      const { url } = await put(pathname, file, { access: 'public', token });
+      const res = await saveLoadDocument({
+        fileName: file.name,
+        fileSize: file.size,
+        mimeType: file.type,
+        url,
+        loadId,
+      });
+      if (res.success && 'data' in res) {
+        onUploaded(res.data as Document);
+        if (inputRef.current) inputRef.current.value = '';
+      } else {
+        setError('error' in res && res.error ? res.error : 'Upload failed');
+      }
+    } catch (err) {
+      setError('Upload error');
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <input ref={inputRef} type="file" onChange={handleChange} disabled={uploading} />
+      {uploading && <span>Uploading...</span>}
+      {error && <span className="text-red-500">{error}</span>}
+    </div>
+  );
+}

--- a/components/dispatch/load-documents.tsx
+++ b/components/dispatch/load-documents.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { use, useState } from 'react';
+import { LoadDocumentUploadForm } from './load-document-upload-form';
+import { LoadDocumentList } from './load-document-list';
+import { getLoadDocuments } from '@/lib/actions/documentActions';
+import type { Document } from '@/types/dispatch';
+
+interface LoadDocumentsProps {
+  orgId: string;
+  loadId: string;
+}
+
+export function LoadDocuments({ orgId, loadId }: LoadDocumentsProps) {
+  const [docs, setDocs] = useState<Document[]>(() => {
+    const res = use(getLoadDocuments(orgId, loadId));
+    return res.success && 'data' in res ? (res.data as Document[]) : [];
+  });
+
+  const refresh = async () => {
+    const res = await getLoadDocuments(orgId, loadId);
+    if (res.success && 'data' in res) {
+      setDocs(res.data as Document[]);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <LoadDocumentUploadForm orgId={orgId} loadId={loadId} onUploaded={() => refresh()} />
+      <LoadDocumentList orgId={orgId} documents={docs} refresh={refresh} />
+    </div>
+  );
+}

--- a/docs/Developer-Documentation.md
+++ b/docs/Developer-Documentation.md
@@ -447,8 +447,8 @@ aspects of the schema include:
 
 - **Compliance & Documents:**
 
-  - **documents** – A general table for uploaded documents (could be used for storing file meta like
-    URL, upload date).
+  - **documents** – A general table for uploaded files. Each record stores file metadata and can be linked to a
+    load via `loadId` for proof of delivery or other paperwork.
   - **compliance_documents** – (If distinct from documents) Stores specific compliance record
     entries, such as a record of a driver's license or a vehicle inspection, possibly linking to an
     entry in `documents` for the file itself. Also linked to the relevant driver/vehicle and

--- a/docs/User-Documentation.md
+++ b/docs/User-Documentation.md
@@ -325,7 +325,8 @@ own compliance tasks like hours-of-service logs or document uploads.
    delivered goods).
 3. Choose the document type if prompted (e.g., "Proof of Delivery") and add any notes required.
 4. Submit the upload. The document will be attached to the load record for dispatchers and
-   compliance officers to review.
+   compliance officers to review. Uploaded files appear in a list where you can also delete
+   unwanted documents.
 
 **Logging Hours (if applicable):**
 

--- a/lib/actions/documentActions.ts
+++ b/lib/actions/documentActions.ts
@@ -1,0 +1,64 @@
+'use server';
+
+import { z } from 'zod';
+import { getCurrentUser } from '@/lib/auth/auth';
+import { handleError } from '@/lib/errors/handleError';
+import db from '@/lib/database/db';
+
+export const loadDocumentSchema = z.object({
+  fileName: z.string().min(1),
+  fileSize: z.number().min(1),
+  mimeType: z.string().min(1),
+  url: z.string().url(),
+  loadId: z.string().min(1),
+});
+
+export async function saveLoadDocument(data: z.infer<typeof loadDocumentSchema>) {
+  try {
+    const user = await getCurrentUser();
+    const userId = user?.userId;
+    const orgId = user?.organizationId;
+    if (!userId || !orgId) throw new Error('Unauthorized');
+
+    const validated = loadDocumentSchema.parse(data);
+
+    const doc = await db.document.create({
+      data: {
+        organizationId: orgId,
+        loadId: validated.loadId,
+        name: validated.fileName,
+        fileUrl: validated.url,
+        fileSize: validated.fileSize,
+        mimeType: validated.mimeType,
+        uploadedBy: userId,
+        uploadedAt: new Date(),
+      },
+    });
+    return { success: true, data: doc };
+  } catch (error) {
+    return handleError(error, 'Save Load Document');
+  }
+}
+
+export async function deleteLoadDocument(orgId: string, documentId: string) {
+  try {
+    await db.document.delete({
+      where: { id: documentId, organizationId: orgId },
+    });
+    return { success: true, data: null };
+  } catch (error) {
+    return handleError(error, 'Delete Load Document');
+  }
+}
+
+export async function getLoadDocuments(orgId: string, loadId: string) {
+  try {
+    const docs = await db.document.findMany({
+      where: { organizationId: orgId, loadId },
+      orderBy: { uploadedAt: 'desc' },
+    });
+    return { success: true, data: docs };
+  } catch (error) {
+    return handleError(error, 'Get Load Documents');
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,44 +10,45 @@ datasource db {
 }
 
 model Organization {
-  id                  String                   @id @default(uuid())
-  name                String
-  slug                String                   @unique
-  mcNumber            String?                  @map("mc_number")
-  address             String?
-  city                String?
-  state               String?
-  zip                 String?
-  phone               String?
-  email               String?
-  logoUrl             String?                  @map("logo_url")
-  subscriptionTier    SubscriptionTier         @default(starter) @map("subscription_tier")
-  subscriptionStatus  SubscriptionStatus       @default(trial) @map("subscription_status")
-  maxUsers            Int                      @default(5) @map("max_users")
-  billingEmail        String?                  @map("billing_email")
-  settings            Json?                    @default("{\"fuelUnit\": \"gallons\", \"timezone\": \"America/Denver\", \"dateFormat\": \"MM/dd/yyyy\", \"distanceUnit\": \"miles\"}")
-  isActive            Boolean                  @default(true) @map("is_active")
-  createdAt           DateTime                 @default(now()) @map("created_at")
-  updatedAt           DateTime                 @updatedAt @map("updated_at")
-  dotNumber           String?
-  auditLogs           AuditLog[]
-  notifications       Notification[]
-  complianceAlerts    ComplianceAlert[]
-  complianceDocuments ComplianceDocument[]
-  drivers             Driver[]
-  IftaFuelPurchase    IftaFuelPurchase[]
-  iftaReports         IftaReport[]
-  IftaTrip            IftaTrip[]
-  loads               Load[]
-  memberships         OrganizationMembership[]
-  users               User[]
-  vehicles            Vehicle[]
-  trailers            Trailer[]
-  customers           Customer[]  
-  dispatchActivities  DispatchActivity[]
+  id                     String                   @id @default(uuid())
+  name                   String
+  slug                   String                   @unique
+  mcNumber               String?                  @map("mc_number")
+  address                String?
+  city                   String?
+  state                  String?
+  zip                    String?
+  phone                  String?
+  email                  String?
+  logoUrl                String?                  @map("logo_url")
+  subscriptionTier       SubscriptionTier         @default(starter) @map("subscription_tier")
+  subscriptionStatus     SubscriptionStatus       @default(trial) @map("subscription_status")
+  maxUsers               Int                      @default(5) @map("max_users")
+  billingEmail           String?                  @map("billing_email")
+  settings               Json?                    @default("{\"fuelUnit\": \"gallons\", \"timezone\": \"America/Denver\", \"dateFormat\": \"MM/dd/yyyy\", \"distanceUnit\": \"miles\"}")
+  isActive               Boolean                  @default(true) @map("is_active")
+  createdAt              DateTime                 @default(now()) @map("created_at")
+  updatedAt              DateTime                 @updatedAt @map("updated_at")
+  dotNumber              String?
+  auditLogs              AuditLog[]
+  notifications          Notification[]
+  complianceAlerts       ComplianceAlert[]
+  complianceDocuments    ComplianceDocument[]
+  drivers                Driver[]
+  IftaFuelPurchase       IftaFuelPurchase[]
+  iftaReports            IftaReport[]
+  IftaTrip               IftaTrip[]
+  loads                  Load[]
+  memberships            OrganizationMembership[]
+  users                  User[]
+  vehicles               Vehicle[]
+  trailers               Trailer[]
+  customers              Customer[]
+  dispatchActivities     DispatchActivity[]
   analyticsFilterPresets AnalyticsFilterPreset[]
-  invitations         OrganizationInvitation[]
-  jurisdictionTaxRates JurisdictionTaxRate[]
+  invitations            OrganizationInvitation[]
+  jurisdictionTaxRates   JurisdictionTaxRate[]
+  Document               Document[]
 
   @@index([slug])
   @@map("organizations")
@@ -81,6 +82,7 @@ model User {
   memberships                   OrganizationMembership[]
   analyticsFilterPresets        AnalyticsFilterPreset[]
   organization                  Organization?            @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  Document                      Document[]
 
   @@index([organizationId])
   @@index([email])
@@ -272,6 +274,7 @@ model Load {
   customer              Customer?         @relation(fields: [customerId], references: [id])
   trailerId             String?           @map("trailer_id")
   trailer               Trailer?          @relation("TrailerLoads", fields: [trailerId], references: [id])
+  Document              Document[]
 
   @@unique([organizationId, loadNumber], name: "loads_org_load_unique")
   @@index([organizationId])
@@ -638,19 +641,19 @@ model IftaTaxCalculation {
 }
 
 model JurisdictionTaxRate {
-  id             String       @id @default(uuid())
-  organizationId String?      @map("organization_id")
-  jurisdiction   String       @map("jurisdiction")
-  taxRate        Decimal      @map("tax_rate") @db.Decimal(10, 4)
-  effectiveDate  DateTime     @map("effective_date")
-  endDate        DateTime?    @map("end_date")
-  source         String       @default("MANUAL")
-  verifiedDate   DateTime     @map("verified_date")
-  isActive       Boolean      @default(true) @map("is_active")
-  createdBy      String?      @map("created_by")
+  id             String        @id @default(uuid())
+  organizationId String?       @map("organization_id")
+  jurisdiction   String        @map("jurisdiction")
+  taxRate        Decimal       @map("tax_rate") @db.Decimal(10, 4)
+  effectiveDate  DateTime      @map("effective_date")
+  endDate        DateTime?     @map("end_date")
+  source         String        @default("MANUAL")
+  verifiedDate   DateTime      @map("verified_date")
+  isActive       Boolean       @default(true) @map("is_active")
+  createdBy      String?       @map("created_by")
   notes          String?
-  createdAt      DateTime     @default(now()) @map("created_at")
-  updatedAt      DateTime     @updatedAt @map("updated_at")
+  createdAt      DateTime      @default(now()) @map("created_at")
+  updatedAt      DateTime      @updatedAt @map("updated_at")
   organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   @@index([organizationId])
@@ -763,4 +766,23 @@ enum InvitationStatus {
   pending
   accepted
   revoked
+}
+
+model Document {
+  id             String       @id @default(uuid())
+  organizationId String       @map("organization_id")
+  loadId         String       @map("load_id")
+  name           String
+  fileUrl        String       @map("file_url")
+  fileSize       Int?         @map("file_size")
+  mimeType       String?      @map("mime_type")
+  uploadedAt     DateTime     @default(now()) @map("uploaded_at")
+  uploadedBy     String       @map("uploaded_by")
+  load           Load         @relation(fields: [loadId], references: [id], onDelete: Cascade)
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  uploadedByUser User         @relation(fields: [uploadedBy], references: [id])
+
+  @@index([organizationId])
+  @@index([loadId])
+  @@map("documents")
 }

--- a/tests/domains/dispatch/documentActions.test.ts
+++ b/tests/domains/dispatch/documentActions.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { saveLoadDocument, deleteLoadDocument } from '../../../lib/actions/documentActions';
+import { getCurrentUser } from '../../../lib/auth/auth';
+
+vi.mock('../../../lib/auth/auth', () => ({ getCurrentUser: vi.fn() }));
+vi.mock('../../../lib/database/db', () => ({
+  __esModule: true,
+  default: {
+    document: {
+      create: vi.fn().mockResolvedValue({ id: 'doc1' }),
+      delete: vi.fn().mockResolvedValue({}),
+    },
+  },
+}));
+vi.mock('../../../lib/errors/handleError', () => ({ handleError: vi.fn((e: any) => ({ success: false, error: String(e) })) }));
+
+import db from '../../../lib/database/db';
+
+describe('dispatch document actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getCurrentUser as any).mockResolvedValue({ userId: 'u1', organizationId: 'org1' });
+  });
+
+  it('saves a load document', async () => {
+    const res = await saveLoadDocument({
+      fileName: 'test.pdf',
+      fileSize: 10,
+      mimeType: 'application/pdf',
+      url: 'http://example.com',
+      loadId: 'load1',
+    });
+    expect(res.success).toBe(true);
+    expect(db.document.create).toHaveBeenCalled();
+  });
+
+  it('deletes a load document', async () => {
+    const res = await deleteLoadDocument('org1', 'doc1');
+    expect(res.success).toBe(true);
+    expect(db.document.delete).toHaveBeenCalled();
+  });
+});

--- a/types/dispatch.ts
+++ b/types/dispatch.ts
@@ -71,7 +71,7 @@ export interface Load {
   notes?: string;
   internalNotes?: string;
   specialInstructions?: string;
-  documents?: LoadDocument[];
+  documents?: Document[];
   statusEvents: LoadStatusEvent[];
   trackingUpdates?: TrackingUpdate[];
   brokerInfo?: BrokerInfo;
@@ -255,6 +255,17 @@ export interface Customer {
   isActive: boolean;
   createdAt: Date;
   updatedAt: Date;
+}
+
+export interface Document {
+  id: string;
+  loadId: string;
+  name: string;
+  url: string;
+  fileSize: number;
+  mimeType: string;
+  uploadedAt: Date;
+  uploadedBy: string;
 }
 
 export interface LoadDocument {


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: dispatch
Milestone: Core

## Description
Adds document management for loads. The Prisma schema now includes a `Document` model linked to `Load`. Dispatch actions provide upload/delete utilities using blob storage. Load details dialog now embeds a document manager component for uploading and listing documents. Documentation and tests updated accordingly.

## Related Issue
Closes #38 - Dispatch feature: Load document uploads (Core)

## Wave Dependencies
- Builds on: initial dispatch load handling
- Enables: future integrations for driver uploads
- Cross-domain integration: none

## Domain Impact
- Primary domain: dispatch
- Files modified: `components/dispatch/*`, `lib/actions/documentActions.ts`, `prisma/schema.prisma`, `types/dispatch.ts`
- Integration points: blob storage utilities

## Milestone Compliance
- [x] Meets Core complexity requirements
- [x] Aligns with milestone delivery goals
- [x] No scope creep beyond milestone definition

## Wave Completion
- [x] Domain task completed for current wave
- [x] Dependencies resolved or properly managed
- [x] Ready for wave progression

## Testing Performed
- [ ] Domain-specific functionality verified
- [ ] Cross-domain integrations tested
- [ ] Wave dependencies validated
- [ ] Milestone requirements met

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68897098d80883279cb5be3b69280317