### PR TITLE
[Dispatch] fix: reference number mapping (Core) (Closes #38)

### DIFF
--- a/components/dispatch/load-form.tsx
+++ b/components/dispatch/load-form.tsx
@@ -80,7 +80,9 @@ export function LoadForm({ orgId, load, loadId, drivers, vehicles, onClose }: Lo
 
     // DB schema field mapping
     if (formData.has('referenceNumber')) {
-      formData.set('load_number', formData.get('referenceNumber') as string);
+      const ref = formData.get('referenceNumber') as string;
+      formData.set('load_number', ref);
+      formData.set('reference_number', ref);
       formData.delete('referenceNumber');
     }
     if (formData.has('driverId')) {
@@ -160,7 +162,7 @@ export function LoadForm({ orgId, load, loadId, drivers, vehicles, onClose }: Lo
                   <Input
                     id="referenceNumber"
                     name="referenceNumber"
-                    defaultValue={load?.loadNumber || load?.referenceNumber || ''}
+                    defaultValue={load?.referenceNumber || load?.loadNumber || ''}
                     placeholder="e.g., L-1001"
                     required
                   />

--- a/lib/actions/dispatchActions.ts
+++ b/lib/actions/dispatchActions.ts
@@ -20,6 +20,8 @@ export async function createDispatchLoadAction(
 
     // Required fields (schema-accurate)
     const loadNumber = formData.get('load_number') as string;
+    const referenceNumber =
+      (formData.get('reference_number') as string) || loadNumber;
     const originAddress = formData.get('origin_address') as string;
     const originCity = formData.get('origin_city') as string;
     const originState = formData.get('origin_state') as string;
@@ -46,6 +48,7 @@ export async function createDispatchLoadAction(
       data: {
         organizationId: orgId,
         loadNumber,
+        referenceNumber,
         originAddress,
         originCity,
         originState,
@@ -89,6 +92,8 @@ export async function updateDispatchLoadAction(
     const data: Record<string, any> = {};
 
     [
+      'load_number',
+      'reference_number',
       'customer_id',
       'driver_id',
       'vehicle_id',
@@ -113,6 +118,10 @@ export async function updateDispatchLoadAction(
           const schemaKey =
             key === 'scheduled_pickup_date' ? 'scheduledPickupDate' : 'scheduledDeliveryDate';
           data[schemaKey] = val ? new Date(val as string) : null;
+        } else if (key === 'load_number') {
+          data.loadNumber = val;
+        } else if (key === 'reference_number') {
+          data.referenceNumber = val;
         } else if (key.endsWith('_id')) {
           // Map field to schema field
           const schemaKey =
@@ -163,6 +172,14 @@ export async function updateDispatchLoadAction(
         }
       }
     });
+
+    if (data.loadNumber && !data.referenceNumber) {
+      data.referenceNumber = data.loadNumber;
+    }
+
+    if (data.referenceNumber && !data.loadNumber) {
+      data.loadNumber = data.referenceNumber;
+    }
 
     data['lastModifiedBy'] = userId;
     data['updatedAt'] = new Date();

--- a/lib/utils/transformers.ts
+++ b/lib/utils/transformers.ts
@@ -121,7 +121,7 @@ export function transformLoad(raw: any): Load | null {
   return {
     id: raw.id,
     organizationId: raw.organizationId,
-    referenceNumber: raw.referenceNumber || '',
+    referenceNumber: raw.referenceNumber || raw.loadNumber || '',
     status: raw.status || 'pending',
     priority: raw.priority || 'medium',
     customerId: raw.customerId,


### PR DESCRIPTION
## Wave & Domain Context
Wave: 3
Domain: dispatch
Milestone: Core

## Description
Aligns the dispatch load forms and actions so the user provided reference number is stored correctly. The dispatch actions now write both `loadNumber` and `referenceNumber` while transformers and UI default to the reference number value.

## Related Issue
Closes #38 - Dispatch Bug: Reference number not saved (Core)

## Wave Dependencies
- Builds on: none
- Enables: future load management tasks
- Cross-domain integration: none

## Domain Impact
- Primary domain: dispatch
- Files modified: `components/dispatch/load-form.tsx`, `lib/actions/dispatchActions.ts`, `lib/utils/transformers.ts`
- Integration points: none

## Milestone Compliance
- [x] Meets Core complexity requirements
- [x] Aligns with milestone delivery goals
- [x] No scope creep

## Wave Completion
- [x] Domain task completed for current wave
- [x] Dependencies resolved
- [x] Ready for wave progression

## Testing Performed
- [ ] Domain-specific functionality verified
- [ ] Cross-domain integrations tested
- [ ] Wave dependencies validated
- [ ] Milestone requirements met

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68897099d4cc8327abb2669c2fe02065