### PR TITLE
[Dispatch] enhancement: revalidate dispatch paths (Core) (Closes #38)

### DIFF
--- a/docs/Developer-Documentation.md
+++ b/docs/Developer-Documentation.md
@@ -577,7 +577,7 @@ All tenant-specific pages are now under:
 
 - `app/(tenant)/[orgId]/dashboard/page.tsx`
 - `app/(tenant)/[orgId]/analytics/page.tsx`
-- `app/(tenant)/[orgId]/dispatch/page.tsx`
+- `app/(tenant)/[orgId]/dispatch/[userId]/page.tsx`
 - `app/(tenant)/[orgId]/drivers/page.tsx`
 - `app/(tenant)/[orgId]/drivers/[userId]/page.tsx`
 - `app/(tenant)/[orgId]/compliance/page.tsx`

--- a/lib/actions/dispatchActions.ts
+++ b/lib/actions/dispatchActions.ts
@@ -66,7 +66,9 @@ export async function createDispatchLoadAction(
       },
     });
 
-    revalidatePath(`/${orgId}/loads`);
+    // Revalidate the dispatch board for all users in this organization
+    // Using the layout option ensures the entire dispatch section is refreshed
+    revalidatePath(`/${orgId}/dispatch`, 'layout');
     return { success: true, data: { id: load.id } };
   } catch (error) {
     return handleError(error, 'Create Load');
@@ -183,7 +185,8 @@ export async function updateDispatchLoadAction(
       },
     });
 
-    revalidatePath(`/${orgId}/dispatch`);
+    // Ensure all dispatch board pages show the latest data
+    revalidatePath(`/${orgId}/dispatch`, 'layout');
     return { success: true, data: { id: loadId } };
   } catch (error) {
     return handleError(error, 'Update Dispatch Load');
@@ -216,7 +219,8 @@ export async function deleteDispatchLoadAction(
       },
     });
 
-    revalidatePath(`/${orgId}/dispatch`);
+    // Revalidate the entire dispatch section for this organization
+    revalidatePath(`/${orgId}/dispatch`, 'layout');
     return { success: true, data: null };
   } catch (error) {
     return handleError(error, 'Delete Dispatch Load');
@@ -256,7 +260,8 @@ export async function assignDriverToLoadAction(
       },
     });
 
-    revalidatePath(`/${orgId}/dispatch`);
+    // Revalidate dispatch board to reflect new driver assignment
+    revalidatePath(`/${orgId}/dispatch`, 'layout');
     return { success: true, data: { id: loadId } };
   } catch (error) {
     return handleError(error, 'Assign Driver to Load');
@@ -306,7 +311,8 @@ export async function updateLoadStatusAction(
       },
     });
 
-    revalidatePath(`/${orgId}/dispatch`);
+    // Revalidate dispatch views so the updated status is visible
+    revalidatePath(`/${orgId}/dispatch`, 'layout');
     return { success: true, data: { id: loadId } };
   } catch (error) {
     return handleError(error, 'Update Load Status');


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: dispatch
Milestone: Core

## Description
Updated dispatch server actions to revalidate the correct board path using layout-level invalidation. Documentation now reflects the dynamic route `/[orgId]/dispatch/[userId]`.

## Related Issue
Closes #38 - Dispatch Enhancement: Add path revalidation (Core)

## Wave Dependencies
- Builds on: none
- Enables: accurate board caching
- Cross-domain integration: none

## Domain Impact
- Primary domain: dispatch
- Files modified: `lib/actions/dispatchActions.ts`, `docs/Developer-Documentation.md`
- Integration points: navigation links use the confirmed path

## Milestone Compliance
- [x] Meets Core complexity requirements
- [x] Aligns with milestone delivery goals
- [x] No scope creep beyond milestone definition

## Wave Completion
- [x] Domain task completed for current wave
- [x] Dependencies resolved or properly managed
- [x] Ready for wave progression

## Testing Performed
- [ ] Domain-specific functionality verified
- [ ] Cross-domain integrations tested
- [ ] Wave dependencies validated
- [ ] Milestone requirements met

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6889709b9ab483279cba60f24e2051ee