### PR TITLE
[Dispatch] enhancement: add form validation errors (Core) (Closes #38)

### DIFF
--- a/components/dispatch/load-form.tsx
+++ b/components/dispatch/load-form.tsx
@@ -1,6 +1,9 @@
 'use client';
 
 import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -19,6 +22,7 @@ import { toast } from '@/hooks/use-toast';
 import { createDispatchLoadAction, updateDispatchLoadAction } from '@/lib/actions/dispatchActions';
 import { AddressFields } from '@/components/shared/AddressFields';
 import { ContactFields } from '@/components/shared/ContactFields';
+import { loadInputSchema } from '@/schemas/dispatch';
 
 interface DriverOption {
   id: string;
@@ -39,6 +43,8 @@ interface LoadFormProps {
   onClose?: () => void;
 }
 
+type LoadInput = z.infer<typeof loadInputSchema>;
+
 export function LoadForm({ orgId, load, loadId, drivers, vehicles, onClose }: LoadFormProps) {
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -46,64 +52,56 @@ export function LoadForm({ orgId, load, loadId, drivers, vehicles, onClose }: Lo
   const tractors = vehicles.filter((v) => v.type === 'tractor');
   const trailers = vehicles.filter((v) => v.type === 'trailer');
 
-  // Pre-fill fields for edit mode
-  const originValues = load
-    ? {
-        address: load.originAddress || '',
-        city: load.originCity || '',
-        state: load.originState || '',
-        zip: load.originZip || '',
-      }
-    : { address: '', city: '', state: '', zip: '' };
+  const form = useForm<LoadInput>({
+    resolver: zodResolver(loadInputSchema),
+    defaultValues: {
+      load_number: load?.loadNumber || '',
+      origin_address: load?.originAddress || '',
+      origin_city: load?.originCity || '',
+      origin_state: load?.originState || '',
+      origin_zip: load?.originZip || '',
+      destination_address: load?.destinationAddress || '',
+      destination_city: load?.destinationCity || '',
+      destination_state: load?.destinationState || '',
+      destination_zip: load?.destinationZip || '',
+      customer_id: load?.customerId || '',
+      driver_id: load?.driver_id || '',
+      vehicle_id: load?.vehicle_id || '',
+      trailer_id: load?.trailer_id || '',
+      scheduled_pickup_date: load?.scheduledPickupDate
+        ? new Date(load.scheduledPickupDate).toISOString().slice(0, 16)
+        : '',
+      scheduled_delivery_date: load?.scheduledDeliveryDate
+        ? new Date(load.scheduledDeliveryDate).toISOString().slice(0, 16)
+        : '',
+      notes: load?.notes || '',
+      status: load?.status || 'pending',
+    },
+  });
+  const { register, handleSubmit, formState: { errors }, setError } = form;
 
-  const destinationValues = load
-    ? {
-        address: load.destinationAddress || '',
-        city: load.destinationCity || '',
-        state: load.destinationState || '',
-        zip: load.destinationZip || '',
-      }
-    : { address: '', city: '', state: '', zip: '' };
-
-  const contactValues = load
-    ? {
-        customerContact: load.customer?.contactName || '',
-        customerPhone: load.customer?.phone || '',
-        customerEmail: load.customer?.email || '',
-      }
-    : { customerContact: '', customerPhone: '', customerEmail: '' };
-
-  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
+  const onSubmit = async (data: LoadInput) => {
     setIsSubmitting(true);
-    const formData = new FormData(event.currentTarget);
-
-    // DB schema field mapping
-    if (formData.has('referenceNumber')) {
-      formData.set('load_number', formData.get('referenceNumber') as string);
-      formData.delete('referenceNumber');
-    }
-    if (formData.has('driverId')) {
-      formData.set('driver_id', formData.get('driverId') as string);
-      formData.delete('driverId');
-    }
-    if (formData.has('vehicleId')) {
-      formData.set('vehicle_id', formData.get('vehicleId') as string);
-      formData.delete('vehicleId');
-    }
-    if (formData.has('trailerId')) {
-      formData.set('trailer_id', formData.get('trailerId') as string);
-      formData.delete('trailerId');
-    }
+    const formData = new FormData();
+    Object.entries(data).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) {
+        formData.append(key, value as string);
+      }
+    });
 
     try {
       let result;
       if (load && (load.id || loadId)) {
-        result = await updateDispatchLoadAction(orgId, load.id || loadId, formData);
+        result = await updateDispatchLoadAction(orgId, load.id || (loadId as string), formData);
         if (result.success) {
           toast({ title: 'Load updated', description: 'Load details updated successfully.' });
           onClose ? onClose() : router.push(`./`);
         } else {
+          if (result.fieldErrors) {
+            for (const [field, messages] of Object.entries(result.fieldErrors)) {
+              setError(field as keyof LoadInput, { message: messages.join(', ') });
+            }
+          }
           toast({
             title: 'Update failed',
             description: result.error || 'Could not update load.',
@@ -116,6 +114,11 @@ export function LoadForm({ orgId, load, loadId, drivers, vehicles, onClose }: Lo
           toast({ title: 'Load created', description: 'New load has been created.' });
           onClose ? onClose() : router.push(`../`);
         } else {
+          if (result.fieldErrors) {
+            for (const [field, messages] of Object.entries(result.fieldErrors)) {
+              setError(field as keyof LoadInput, { message: messages.join(', ') });
+            }
+          }
           toast({
             title: 'Creation failed',
             description: result.error || 'Could not create load.',
@@ -143,7 +146,7 @@ export function LoadForm({ orgId, load, loadId, drivers, vehicles, onClose }: Lo
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <form className="space-y-6" onSubmit={handleSubmit} autoComplete="off">
+        <form className="space-y-6" onSubmit={handleSubmit(onSubmit)} autoComplete="off">
           <Tabs defaultValue="basic" className="w-full">
             <TabsList className="grid w-full grid-cols-4 bg-black border border-gray-700">
               <TabsTrigger value="basic">Basic Info</TabsTrigger>
@@ -156,18 +159,19 @@ export function LoadForm({ orgId, load, loadId, drivers, vehicles, onClose }: Lo
             <TabsContent value="basic" className="mt-4 space-y-4">
               <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                 <div className="space-y-2">
-                  <Label htmlFor="referenceNumber">Reference Number</Label>
+                  <Label htmlFor="load_number">Reference Number</Label>
                   <Input
-                    id="referenceNumber"
-                    name="referenceNumber"
-                    defaultValue={load?.loadNumber || load?.referenceNumber || ''}
+                    id="load_number"
+                    {...register('load_number')}
                     placeholder="e.g., L-1001"
-                    required
                   />
+                  {errors.load_number && (
+                    <p className="text-sm text-red-500">{errors.load_number.message}</p>
+                  )}
                 </div>
                 <div className="space-y-2">
                   <Label htmlFor="status">Status</Label>
-                  <Select name="status" defaultValue={load?.status || 'pending'}>
+                  <Select defaultValue={load?.status || 'pending'} {...register('status')}>
                     <SelectTrigger id="status">
                       <SelectValue placeholder="Select status" />
                     </SelectTrigger>
@@ -179,6 +183,9 @@ export function LoadForm({ orgId, load, loadId, drivers, vehicles, onClose }: Lo
                       <SelectItem value="cancelled">Cancelled</SelectItem>
                     </SelectContent>
                   </Select>
+                  {errors.status && (
+                    <p className="text-sm text-red-500">{errors.status.message}</p>
+                  )}
                 </div>
               </div>
               <div className="space-y-2">
@@ -191,7 +198,7 @@ export function LoadForm({ orgId, load, loadId, drivers, vehicles, onClose }: Lo
                   required
                 />
               </div>
-              <ContactFields values={contactValues} />
+              <ContactFields values={{}} />
             </TabsContent>
 
             {/* Locations tab */}
@@ -202,20 +209,19 @@ export function LoadForm({ orgId, load, loadId, drivers, vehicles, onClose }: Lo
                     <CardTitle>Origin</CardTitle>
                   </CardHeader>
                   <CardContent className="space-y-4">
-                    <AddressFields prefix="origin" values={originValues} required />
+                    <AddressFields prefix="origin" register={register} errors={errors} required />
                     <div className="space-y-2">
-                      <Label htmlFor="scheduledPickupDate">Pickup Date & Time</Label>
+                      <Label htmlFor="scheduled_pickup_date">Pickup Date & Time</Label>
                       <Input
-                        id="scheduledPickupDate"
-                        name="scheduledPickupDate"
+                        id="scheduled_pickup_date"
                         type="datetime-local"
-                        defaultValue={
-                          load?.scheduledPickupDate
-                            ? new Date(load.scheduledPickupDate).toISOString().slice(0, 16)
-                            : ''
-                        }
+                        {...register('scheduled_pickup_date')}
+                        type="datetime-local"
                         required
                       />
+                      {errors.scheduled_pickup_date && (
+                        <p className="text-sm text-red-500">{errors.scheduled_pickup_date.message}</p>
+                      )}
                     </div>
                   </CardContent>
                 </Card>
@@ -224,20 +230,18 @@ export function LoadForm({ orgId, load, loadId, drivers, vehicles, onClose }: Lo
                     <CardTitle>Destination</CardTitle>
                   </CardHeader>
                   <CardContent className="space-y-4">
-                    <AddressFields prefix="destination" values={destinationValues} required />
+                    <AddressFields prefix="destination" register={register} errors={errors} required />
                     <div className="space-y-2">
-                      <Label htmlFor="scheduledDeliveryDate">Delivery Date & Time</Label>
+                      <Label htmlFor="scheduled_delivery_date">Delivery Date & Time</Label>
                       <Input
-                        id="scheduledDeliveryDate"
-                        name="scheduledDeliveryDate"
+                        id="scheduled_delivery_date"
                         type="datetime-local"
-                        defaultValue={
-                          load?.scheduledDeliveryDate
-                            ? new Date(load.scheduledDeliveryDate).toISOString().slice(0, 16)
-                            : ''
-                        }
+                        {...register('scheduled_delivery_date')}
                         required
                       />
+                      {errors.scheduled_delivery_date && (
+                        <p className="text-sm text-red-500">{errors.scheduled_delivery_date.message}</p>
+                      )}
                     </div>
                   </CardContent>
                 </Card>
@@ -247,9 +251,9 @@ export function LoadForm({ orgId, load, loadId, drivers, vehicles, onClose }: Lo
             {/* Assignment tab */}
             <TabsContent value="assignment" className="mt-4 space-y-4">
               <div className="space-y-2">
-                <Label htmlFor="driverId">Driver</Label>
-                <Select name="driverId" defaultValue={load?.driver_id || load?.driver?.id || ''}>
-                  <SelectTrigger id="driverId">
+                <Label htmlFor="driver_id">Driver</Label>
+                <Select defaultValue={load?.driver_id || load?.driver?.id || ''} {...register('driver_id')}>
+                  <SelectTrigger id="driver_id">
                     <SelectValue placeholder="Not Assigned" />
                   </SelectTrigger>
                   <SelectContent>
@@ -263,9 +267,9 @@ export function LoadForm({ orgId, load, loadId, drivers, vehicles, onClose }: Lo
                 </Select>
               </div>
               <div className="space-y-2">
-                <Label htmlFor="vehicleId">Tractor</Label>
-                <Select name="vehicleId" defaultValue={load?.vehicle_id || load?.vehicle?.id || ''}>
-                  <SelectTrigger id="vehicleId">
+                <Label htmlFor="vehicle_id">Tractor</Label>
+                <Select defaultValue={load?.vehicle_id || load?.vehicle?.id || ''} {...register('vehicle_id')}>
+                  <SelectTrigger id="vehicle_id">
                     <SelectValue placeholder="Not Assigned" />
                   </SelectTrigger>
                   <SelectContent>
@@ -279,9 +283,9 @@ export function LoadForm({ orgId, load, loadId, drivers, vehicles, onClose }: Lo
                 </Select>
               </div>
               <div className="space-y-2">
-                <Label htmlFor="trailerId">Trailer</Label>
-                <Select name="trailerId" defaultValue={load?.trailer_id || load?.trailer?.id || ''}>
-                  <SelectTrigger id="trailerId">
+                <Label htmlFor="trailer_id">Trailer</Label>
+                <Select defaultValue={load?.trailer_id || load?.trailer?.id || ''} {...register('trailer_id')}>
+                  <SelectTrigger id="trailer_id">
                     <SelectValue placeholder="Not Assigned" />
                   </SelectTrigger>
                   <SelectContent>
@@ -350,11 +354,13 @@ export function LoadForm({ orgId, load, loadId, drivers, vehicles, onClose }: Lo
                 <Label htmlFor="notes">Notes</Label>
                 <Textarea
                   id="notes"
-                  name="notes"
-                  defaultValue={load?.notes || ''}
+                  {...register('notes')}
                   placeholder="Additional notes or instructions"
                   rows={3}
                 />
+                {errors.notes && (
+                  <p className="text-sm text-red-500">{errors.notes.message}</p>
+                )}
               </div>
             </TabsContent>
           </Tabs>

--- a/components/shared/AddressFields.tsx
+++ b/components/shared/AddressFields.tsx
@@ -1,60 +1,49 @@
 // Shared AddressFields component for DRY compliance
 import React from 'react';
+import type { UseFormRegister, FieldErrors } from 'react-hook-form';
 
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 
-interface AddressFieldsProps {
-  prefix?: string; // e.g., "origin" or "destination" or ""
-  values?: Record<string, string>;
+interface AddressFieldsProps<T extends Record<string, any>> {
+  prefix?: string;
+  register: UseFormRegister<T>;
+  errors: FieldErrors<T>;
   required?: boolean;
 }
 
-export function AddressFields({ prefix = '', values = {}, required = false }: AddressFieldsProps) {
-  const field = (name: string) =>
-    prefix ? `${prefix}${name.charAt(0).toUpperCase() + name.slice(1)}` : name;
+export function AddressFields<T extends Record<string, any>>({ prefix = '', register, errors, required = false }: AddressFieldsProps<T>) {
+  const field = (name: string) => (prefix ? `${prefix}_${name}` : name);
   return (
     <>
       <div className="space-y-2">
         <Label htmlFor={field('address')}>Address</Label>
-        <Input
-          id={field('address')}
-          name={field('address')}
-          defaultValue={values[field('address')] || ''}
-          placeholder="e.g., 123 Main St"
-          required={required}
-        />
+        <Input id={field('address')} {...register(field('address') as any)} placeholder="e.g., 123 Main St" required={required} />
+        {errors[field('address') as keyof FieldErrors<T>] && (
+          <p className="text-sm text-red-500">{String(errors[field('address') as keyof FieldErrors<T>]?.message)}</p>
+        )}
       </div>
       <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
         <div className="space-y-2">
           <Label htmlFor={field('city')}>City</Label>
-          <Input
-            id={field('city')}
-            name={field('city')}
-            defaultValue={values[field('city')] || ''}
-            placeholder="e.g., City"
-            required={required}
-          />
+          <Input id={field('city')} {...register(field('city') as any)} placeholder="e.g., City" required={required} />
+          {errors[field('city') as keyof FieldErrors<T>] && (
+            <p className="text-sm text-red-500">{String(errors[field('city') as keyof FieldErrors<T>]?.message)}</p>
+          )}
         </div>
         <div className="space-y-2">
           <Label htmlFor={field('state')}>State</Label>
-          <Input
-            id={field('state')}
-            name={field('state')}
-            defaultValue={values[field('state')] || ''}
-            placeholder="e.g., ST"
-            required={required}
-          />
+          <Input id={field('state')} {...register(field('state') as any)} placeholder="e.g., ST" required={required} />
+          {errors[field('state') as keyof FieldErrors<T>] && (
+            <p className="text-sm text-red-500">{String(errors[field('state') as keyof FieldErrors<T>]?.message)}</p>
+          )}
         </div>
         <div className="space-y-2">
           <Label htmlFor={field('zip')}>ZIP Code</Label>
-          <Input
-            id={field('zip')}
-            name={field('zip')}
-            defaultValue={values[field('zip')] || ''}
-            placeholder="e.g., 12345"
-            required={required}
-          />
+          <Input id={field('zip')} {...register(field('zip') as any)} placeholder="e.g., 12345" required={required} />
+          {errors[field('zip') as keyof FieldErrors<T>] && (
+            <p className="text-sm text-red-500">{String(errors[field('zip') as keyof FieldErrors<T>]?.message)}</p>
+          )}
         </div>
       </div>
     </>

--- a/lib/actions/dispatchActions.ts
+++ b/lib/actions/dispatchActions.ts
@@ -4,8 +4,8 @@ import { auth } from '@clerk/nextjs/server';
 import { revalidatePath } from 'next/cache';
 import db from '@/lib/database/db';
 import { handleError } from '@/lib/errors/handleError';
-import type { DashboardActionResult } from '@/types/dashboard';
-import type { LoadStatus } from '@/types/dispatch';
+import { loadInputSchema } from '@/schemas/dispatch';
+import type { LoadStatus, LoadActionResult } from '@/types/dispatch';
 
 /**
  * Create a new load (dispatch)
@@ -13,34 +13,41 @@ import type { LoadStatus } from '@/types/dispatch';
 export async function createDispatchLoadAction(
   orgId: string,
   formData: FormData,
-): Promise<DashboardActionResult<{ id: string }>> {
+): Promise<LoadActionResult<{ id: string }>> {
   try {
     const { userId } = await auth();
     if (!userId) return { success: false, error: 'Unauthorized' };
 
-    // Required fields (schema-accurate)
-    const loadNumber = formData.get('load_number') as string;
-    const originAddress = formData.get('origin_address') as string;
-    const originCity = formData.get('origin_city') as string;
-    const originState = formData.get('origin_state') as string;
-    const originZip = formData.get('origin_zip') as string;
-    const destinationAddress = formData.get('destination_address') as string;
-    const destinationCity = formData.get('destination_city') as string;
-    const destinationState = formData.get('destination_state') as string;
-    const destinationZip = formData.get('destination_zip') as string;
+    const parsed = loadInputSchema.safeParse(Object.fromEntries(formData));
+    if (!parsed.success) {
+      return {
+        success: false,
+        error: 'Invalid data',
+        fieldErrors: parsed.error.flatten().fieldErrors as Record<string, string[]>,
+      };
+    }
 
-    // Optionals/nullable
-    const customerId = formData.get('customer_id') as string | null;
-    const driverId = formData.get('driver_id') as string;
-    const vehicleId = formData.get('vehicle_id') as string | null;
-    const trailerId = formData.get('trailer_id') as string | null;
-    const scheduledPickupDate = formData.get('scheduled_pickup_date')
-      ? new Date(formData.get('scheduled_pickup_date') as string)
-      : null;
-    const scheduledDeliveryDate = formData.get('scheduled_delivery_date')
-      ? new Date(formData.get('scheduled_delivery_date') as string)
-      : null;
-    const notes = formData.get('notes') as string | null;
+    const {
+      load_number: loadNumber,
+      origin_address: originAddress,
+      origin_city: originCity,
+      origin_state: originState,
+      origin_zip: originZip,
+      destination_address: destinationAddress,
+      destination_city: destinationCity,
+      destination_state: destinationState,
+      destination_zip: destinationZip,
+      customer_id: customerId,
+      driver_id: driverId,
+      vehicle_id: vehicleId,
+      trailer_id: trailerId,
+      scheduled_pickup_date: pickup,
+      scheduled_delivery_date: delivery,
+      notes,
+    } = parsed.data;
+
+    const scheduledPickupDate = pickup ? new Date(pickup) : null;
+    const scheduledDeliveryDate = delivery ? new Date(delivery) : null;
 
     const load = await db.load.create({
       data: {
@@ -69,7 +76,7 @@ export async function createDispatchLoadAction(
     revalidatePath(`/${orgId}/loads`);
     return { success: true, data: { id: load.id } };
   } catch (error) {
-    return handleError(error, 'Create Load');
+    return handleError(error, 'Create Load') as LoadActionResult<{ id: string }>;
   }
 }
 
@@ -80,89 +87,59 @@ export async function updateDispatchLoadAction(
   orgId: string,
   loadId: string,
   formData: FormData,
-): Promise<DashboardActionResult<{ id: string }>> {
+): Promise<LoadActionResult<{ id: string }>> {
   try {
     const { userId } = await auth();
     if (!userId) return { success: false, error: 'Unauthorized' };
 
-    // Only update fields present in the schema
+    const parsed = loadInputSchema.partial().safeParse(Object.fromEntries(formData));
+    if (!parsed.success) {
+      return {
+        success: false,
+        error: 'Invalid data',
+        fieldErrors: parsed.error.flatten().fieldErrors as Record<string, string[]>,
+      };
+    }
+
+    const {
+      customer_id,
+      driver_id,
+      vehicle_id,
+      trailer_id,
+      origin_address,
+      origin_city,
+      origin_state,
+      origin_zip,
+      destination_address,
+      destination_city,
+      destination_state,
+      destination_zip,
+      scheduled_pickup_date,
+      scheduled_delivery_date,
+      notes,
+      status,
+    } = parsed.data;
+
     const data: Record<string, any> = {};
 
-    [
-      'customer_id',
-      'driver_id',
-      'vehicle_id',
-      'trailer_id',
-      'origin_address',
-      'origin_city',
-      'origin_state',
-      'origin_zip',
-      'destination_address',
-      'destination_city',
-      'destination_state',
-      'destination_zip',
-      'scheduled_pickup_date',
-      'scheduled_delivery_date',
-      'notes',
-      'status',
-    ].forEach((key) => {
-      const val = formData.get(key);
-      if (val !== null && val !== undefined) {
-        // Handle dates
-        if (['scheduled_pickup_date', 'scheduled_delivery_date'].includes(key)) {
-          const schemaKey =
-            key === 'scheduled_pickup_date' ? 'scheduledPickupDate' : 'scheduledDeliveryDate';
-          data[schemaKey] = val ? new Date(val as string) : null;
-        } else if (key.endsWith('_id')) {
-          // Map field to schema field
-          const schemaKey =
-            key === 'customer_id'
-              ? 'customerId'
-              : key === 'driver_id'
-                ? 'driver_id'
-                : key === 'vehicle_id'
-                  ? 'vehicleId'
-                  : key === 'trailer_id'
-                    ? 'trailerId'
-                    : key;
-          data[schemaKey] = val;
-        } else if (
-          [
-            'origin_address',
-            'origin_city',
-            'origin_state',
-            'origin_zip',
-            'destination_address',
-            'destination_city',
-            'destination_state',
-            'destination_zip',
-          ].includes(key)
-        ) {
-          // Map form keys to schema fields
-          const schemaKey =
-            key === 'origin_address'
-              ? 'originAddress'
-              : key === 'origin_city'
-                ? 'originCity'
-                : key === 'origin_state'
-                  ? 'originState'
-                  : key === 'origin_zip'
-                    ? 'originZip'
-                    : key === 'destination_address'
-                      ? 'destinationAddress'
-                      : key === 'destination_city'
-                        ? 'destinationCity'
-                        : key === 'destination_state'
-                          ? 'destinationState'
-                          : key === 'destination_zip'
-                            ? 'destinationZip'
-                            : key;
-          data[schemaKey] = val;
-        } else {
-          data[key] = val;
-        }
-      }
-    });
+    if (customer_id !== undefined) data.customerId = customer_id;
+    if (driver_id !== undefined) data.driver_id = driver_id;
+    if (vehicle_id !== undefined) data.vehicleId = vehicle_id;
+    if (trailer_id !== undefined) data.trailerId = trailer_id;
+    if (origin_address !== undefined) data.originAddress = origin_address;
+    if (origin_city !== undefined) data.originCity = origin_city;
+    if (origin_state !== undefined) data.originState = origin_state;
+    if (origin_zip !== undefined) data.originZip = origin_zip;
+    if (destination_address !== undefined) data.destinationAddress = destination_address;
+    if (destination_city !== undefined) data.destinationCity = destination_city;
+    if (destination_state !== undefined) data.destinationState = destination_state;
+    if (destination_zip !== undefined) data.destinationZip = destination_zip;
+    if (scheduled_pickup_date !== undefined)
+      data.scheduledPickupDate = scheduled_pickup_date ? new Date(scheduled_pickup_date) : null;
+    if (scheduled_delivery_date !== undefined)
+      data.scheduledDeliveryDate = scheduled_delivery_date ? new Date(scheduled_delivery_date) : null;
+    if (notes !== undefined) data.notes = notes;
+    if (status !== undefined) data.status = status;
 
     data['lastModifiedBy'] = userId;
     data['updatedAt'] = new Date();
@@ -186,7 +163,7 @@ export async function updateDispatchLoadAction(
     revalidatePath(`/${orgId}/dispatch`);
     return { success: true, data: { id: loadId } };
   } catch (error) {
-    return handleError(error, 'Update Dispatch Load');
+    return handleError(error, 'Update Dispatch Load') as LoadActionResult<{ id: string }>;
   }
 }
 

--- a/tests/domains/dispatch/loadForm.test.tsx
+++ b/tests/domains/dispatch/loadForm.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { LoadForm } from '@/components/dispatch/load-form';
+import React from 'react';
+
+describe('LoadForm validation', () => {
+  it('shows validation errors for required fields', async () => {
+    render(
+      <LoadForm orgId="org1" drivers={[]} vehicles={[]} />,
+    );
+    await userEvent.click(screen.getByRole('button', { name: /create load/i }));
+    expect(await screen.findByText('Load number is required')).toBeInTheDocument();
+    expect(screen.getByText('Origin address is required')).toBeInTheDocument();
+    expect(screen.getByText('Destination address is required')).toBeInTheDocument();
+  });
+});

--- a/types/dispatch.ts
+++ b/types/dispatch.ts
@@ -359,3 +359,8 @@ export interface AssignmentMeta {
   trailerAssignedAt?: Date;
   trailerAssignedBy?: string;
 }
+
+export interface LoadActionResult<T = { id: string }> extends import('./actions').ActionResult<T> {
+  fieldErrors?: Record<string, string[]>;
+}
+


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: dispatch
Milestone: Core

## Description
Adds Zod-based validation with structured errors to dispatch load actions and integrates react-hook-form error display in the LoadForm component. Includes unit tests verifying that invalid inputs show messages next to the fields.

## Related Issue
Closes #38 - Dispatch enhancement: structured validation errors (Core)

## Wave Dependencies
- Builds on: initial dispatch forms
- Enables: future validation improvements
- Cross-domain integration: none

## Domain Impact
- Primary domain: dispatch
- Files modified: `lib/actions/dispatchActions.ts`, `components/dispatch/load-form.tsx`, `components/shared/AddressFields.tsx`, `types/dispatch.ts`, `tests/domains/dispatch/loadForm.test.tsx`
- Integration points: none

## Milestone Compliance
- [ ] Meets Core complexity requirements
- [ ] Aligns with milestone delivery goals
- [ ] No scope creep beyond milestone definition

## Wave Completion
- [ ] Domain task completed for current wave
- [ ] Dependencies resolved or properly managed
- [ ] Ready for wave progression

## Testing Performed
- [ ] Domain-specific functionality verified
- [ ] Cross-domain integrations tested
- [ ] Wave dependencies validated
- [ ] Milestone requirements met

------
https://chatgpt.com/codex/tasks/task_e_6889709d0af88327aa4549c3f284aa6e