### PR TITLE
[Settings] fix: add error handling for server actions (Core) (Closes #0)

### DIFF
--- a/lib/actions/auditLogActions.ts
+++ b/lib/actions/auditLogActions.ts
@@ -1,37 +1,56 @@
 'use server';
 
 import type { z } from 'zod';
+import type { AuditLog } from '@prisma/client';
 
 import db from '../database/db';
 import { auditLogSchema } from '@/schemas/auditLogSchema';
+import { handleError } from '@/lib/errors/handleError';
+import type { ActionResult } from '@/types/actions';
 
 // Removed auditLogSchema export and imported from auditLogSchema.ts
 // ...existing code...
 
-export async function createAuditLog(data: z.infer<typeof auditLogSchema>) {
-  const validated = auditLogSchema.parse(data);
-  return db.auditLog.create({
-    data: {
-      organizationId: validated.organizationId,
-      userId: validated.userId,
-      entityType: validated.entityType,
-      entityId: validated.entityId,
-      action: validated.action,
-      changes: validated.changes,
-      metadata: validated.metadata,
-      timestamp: new Date(),
-    },
-  });
+export async function createAuditLog(
+  data: z.infer<typeof auditLogSchema>,
+): Promise<ActionResult<AuditLog>> {
+  try {
+    const validated = auditLogSchema.parse(data);
+    const log = await db.auditLog.create({
+      data: {
+        organizationId: validated.organizationId,
+        userId: validated.userId,
+        entityType: validated.entityType,
+        entityId: validated.entityId,
+        action: validated.action,
+        changes: validated.changes,
+        metadata: validated.metadata,
+        timestamp: new Date(),
+      },
+    });
+    return { success: true, data: log };
+  } catch (error) {
+    return handleError(error, 'Create Audit Log');
+  }
 }
 
-export async function getAuditLogs(organizationId: string, entityType?: string, entityId?: string) {
-  return db.auditLog.findMany({
-    where: {
-      organizationId,
-      ...(entityType ? { entityType } : {}),
-      ...(entityId ? { entityId } : {}),
-    },
-    orderBy: { timestamp: 'desc' },
-    take: 100,
-  });
+export async function getAuditLogs(
+  organizationId: string,
+  entityType?: string,
+  entityId?: string,
+): Promise<ActionResult<AuditLog[]>> {
+  try {
+    const logs = await db.auditLog.findMany({
+      where: {
+        organizationId,
+        ...(entityType ? { entityType } : {}),
+        ...(entityId ? { entityId } : {}),
+      },
+      orderBy: { timestamp: 'desc' },
+      take: 100,
+    });
+    return { success: true, data: logs };
+  } catch (error) {
+    return handleError(error, 'Get Audit Logs');
+  }
 }

--- a/lib/actions/settingsActions.ts
+++ b/lib/actions/settingsActions.ts
@@ -3,13 +3,15 @@
 import { auth } from '@clerk/nextjs/server';
 import { revalidatePath } from 'next/cache';
 import db from '@/lib/database/db';
-import type { Prisma } from '@prisma/client';
+import type { Prisma, Organization } from '@prisma/client';
 import {
   CompanyProfileSchema,
   OrganizationSettingsSchema,
   UserPreferencesSchema,
   NotificationSettingsSchema,
 } from '@/schemas/settings';
+import { handleError } from '@/lib/errors/handleError';
+import type { ActionResult } from '@/types/actions';
 
 async function verifyOrgAccess(orgId: string) {
   const { userId, orgId: sessionOrg } = await auth();
@@ -32,64 +34,109 @@ async function logChange(orgId: string, userId: string, action: string) {
   });
 }
 
-export async function updateCompanyProfileAction(orgId: string, data: unknown) {
-  const userId = await verifyOrgAccess(orgId);
-  const parsed = CompanyProfileSchema.parse(data);
-  await logChange(orgId, userId, 'updateCompanyProfile');
-  return { success: true };
+export async function updateCompanyProfileAction(
+  orgId: string,
+  data: unknown,
+): Promise<ActionResult<void>> {
+  try {
+    const userId = await verifyOrgAccess(orgId);
+    const _parsed = CompanyProfileSchema.parse(data);
+    await logChange(orgId, userId, 'updateCompanyProfile');
+    return { success: true };
+  } catch (error) {
+    return handleError(error, 'Update Company Profile');
+  }
 }
 
-export async function updateOrganizationSettings(orgId: string, data: unknown) {
-  const userId = await verifyOrgAccess(orgId);
-  const parsed = OrganizationSettingsSchema.parse(data);
-  const result = await db.organization.update({
-    where: { id: orgId },
-    data: {
-      name: parsed.name,
-      address: parsed.address,
-      logoUrl: parsed.logoUrl,
-      settings: {
-        timezone: parsed.timezone,
+export async function updateOrganizationSettings(
+  orgId: string,
+  data: unknown,
+): Promise<ActionResult<Organization>> {
+  try {
+    const userId = await verifyOrgAccess(orgId);
+    const parsed = OrganizationSettingsSchema.parse(data);
+    const result = await db.organization.update({
+      where: { id: orgId },
+      data: {
+        name: parsed.name,
+        address: parsed.address,
+        logoUrl: parsed.logoUrl,
+        settings: {
+          timezone: parsed.timezone,
+        },
       },
-    },
-  });
-  await logChange(orgId, userId, 'updateOrganization');
-  revalidatePath(`/[orgId]/settings`);
-  return result;
+    });
+    await logChange(orgId, userId, 'updateOrganization');
+    revalidatePath(`/[orgId]/settings`);
+    return { success: true, data: result };
+  } catch (error) {
+    return handleError(error, 'Update Organization Settings');
+  }
 }
 
-export async function updateUserPreferences(data: unknown) {
-  const { userId } = await auth();
-  if (!userId) throw new Error('Unauthorized');
-  const parsed = UserPreferencesSchema.parse(data);
-  if (parsed.userId !== userId) throw new Error('Invalid user');
-  await logChange(parsed.userId, parsed.userId, 'updateUserPrefs');
-  return { success: true };
+export async function updateUserPreferences(
+  data: unknown,
+): Promise<ActionResult<void>> {
+  try {
+    const { userId } = await auth();
+    if (!userId) throw new Error('Unauthorized');
+    const parsed = UserPreferencesSchema.parse(data);
+    if (parsed.userId !== userId) throw new Error('Invalid user');
+    await logChange(parsed.userId, parsed.userId, 'updateUserPrefs');
+    return { success: true };
+  } catch (error) {
+    return handleError(error, 'Update User Preferences');
+  }
 }
 
-export async function updateNotificationSettings(data: unknown) {
-  const { userId } = await auth();
-  if (!userId) throw new Error('Unauthorized');
-  const parsed = NotificationSettingsSchema.parse(data);
-  if (parsed.userId !== userId) throw new Error('Invalid user');
-  await logChange(parsed.userId, parsed.userId, 'updateNotifications');
-  return { success: true };
+export async function updateNotificationSettings(
+  data: unknown,
+): Promise<ActionResult<void>> {
+  try {
+    const { userId } = await auth();
+    if (!userId) throw new Error('Unauthorized');
+    const parsed = NotificationSettingsSchema.parse(data);
+    if (parsed.userId !== userId) throw new Error('Invalid user');
+    await logChange(parsed.userId, parsed.userId, 'updateNotifications');
+    return { success: true };
+  } catch (error) {
+    return handleError(error, 'Update Notification Settings');
+  }
 }
 
-export async function updateIntegrationSettings(orgId: string, data: unknown) {
-  const userId = await verifyOrgAccess(orgId);
-  await logChange(orgId, userId, 'updateIntegrations');
-  return { success: true };
+export async function updateIntegrationSettings(
+  orgId: string,
+  data: unknown,
+): Promise<ActionResult<void>> {
+  try {
+    const userId = await verifyOrgAccess(orgId);
+    await logChange(orgId, userId, 'updateIntegrations');
+    return { success: true };
+  } catch (error) {
+    return handleError(error, 'Update Integration Settings');
+  }
 }
 
-export async function resetSettingsToDefault(orgId: string) {
-  const userId = await verifyOrgAccess(orgId);
-  await logChange(orgId, userId, 'resetSettings');
-  return { success: true };
+export async function resetSettingsToDefault(
+  orgId: string,
+): Promise<ActionResult<void>> {
+  try {
+    const userId = await verifyOrgAccess(orgId);
+    await logChange(orgId, userId, 'resetSettings');
+    return { success: true };
+  } catch (error) {
+    return handleError(error, 'Reset Settings To Default');
+  }
 }
 
-export async function exportSettings(orgId: string) {
-  await verifyOrgAccess(orgId);
-  const org = await db.organization.findUnique({ where: { id: orgId } });
-  return org?.settings || {};
+export async function exportSettings(
+  orgId: string,
+): Promise<ActionResult<Prisma.JsonValue>> {
+  try {
+    await verifyOrgAccess(orgId);
+    const org = await db.organization.findUnique({ where: { id: orgId } });
+    return { success: true, data: (org?.settings as Prisma.JsonValue) || {} };
+  } catch (error) {
+    return handleError(error, 'Export Settings');
+  }
 }


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: settings
Milestone: Core

## Description
Adds try/catch blocks with centralized `handleError` usage across audit log and settings server actions, returning consistent `ActionResult` objects.

## Related Issue
Closes #0 - [Settings] fix: add error handling for server actions (Core)

## Wave Dependencies
- Builds on: N/A
- Enables: N/A
- Cross-domain integration: compliance audit logs

## Domain Impact
- Primary domain: settings
- Files modified: lib/actions/settingsActions.ts, lib/actions/auditLogActions.ts
- Integration points: compliance audit log system

## Milestone Compliance
- [x] Meets Core complexity requirements
- [x] Aligns with milestone delivery goals
- [x] No scope creep beyond milestone definition

## Wave Completion
- [x] Domain task completed for current wave
- [x] Dependencies resolved or properly managed
- [x] Ready for wave progression

## Testing Performed
- [ ] Domain-specific functionality verified
- [ ] Cross-domain integrations tested
- [x] Wave dependencies validated
- [ ] Milestone requirements met
- `npm test` *(fails: module mocking errors, invalid Chai properties, and other test failures)*


------
https://chatgpt.com/codex/tasks/task_e_68973ffd3d5c8327b256a57b984cfbcb