### PR TITLE
[Dispatch] test: add load creation and board verification tests (MVP) (Closes #123)

### DIFF
--- a/tests/domains/dispatch/dispatchActions.test.ts
+++ b/tests/domains/dispatch/dispatchActions.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }));
+
+const authMock = vi.fn();
+vi.mock('@clerk/nextjs/server', () => ({ auth: authMock }));
+
+const dbMock = {
+  load: {
+    create: vi.fn(),
+    findUnique: vi.fn(),
+    update: vi.fn(),
+  },
+  loadStatusEvent: { create: vi.fn() },
+  dispatchActivity: { create: vi.fn() },
+};
+
+vi.mock('../../../lib/database/db', () => ({ __esModule: true, default: dbMock }));
+vi.mock('../../../lib/errors/handleError', () => ({ handleError: vi.fn() }));
+
+describe('dispatch actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates a load when authorized', async () => {
+    authMock.mockResolvedValue({ userId: 'u1' });
+    dbMock.load.create.mockResolvedValue({ id: 'l1' });
+    const formData = new FormData();
+    formData.append('load_number', 'L-1001');
+    formData.append('origin_address', '123 Main');
+    formData.append('origin_city', 'City');
+    formData.append('origin_state', 'CA');
+    formData.append('origin_zip', '90001');
+    formData.append('destination_address', '456 Oak');
+    formData.append('destination_city', 'Town');
+    formData.append('destination_state', 'CA');
+    formData.append('destination_zip', '90002');
+
+    const { createDispatchLoadAction } = await import('../../../lib/actions/dispatchActions');
+    const res = await createDispatchLoadAction('org1', formData);
+    expect(res).toEqual({ success: true, data: { id: 'l1' } });
+    expect(dbMock.load.create).toHaveBeenCalled();
+  });
+
+  it('prevents load creation when unauthorized', async () => {
+    authMock.mockResolvedValue({ userId: null });
+    const formData = new FormData();
+    formData.append('load_number', 'L-1001');
+    formData.append('origin_address', '123 Main');
+    formData.append('origin_city', 'City');
+    formData.append('origin_state', 'CA');
+    formData.append('origin_zip', '90001');
+    formData.append('destination_address', '456 Oak');
+    formData.append('destination_city', 'Town');
+    formData.append('destination_state', 'CA');
+    formData.append('destination_zip', '90002');
+
+    const { createDispatchLoadAction } = await import('../../../lib/actions/dispatchActions');
+    const res = await createDispatchLoadAction('org1', formData);
+    expect(res).toEqual({ success: false, error: 'Unauthorized' });
+    expect(dbMock.load.create).not.toHaveBeenCalled();
+  });
+
+  it('updates status when transition is allowed', async () => {
+    authMock.mockResolvedValue({ userId: 'u1' });
+    dbMock.load.findUnique.mockResolvedValue({ status: 'assigned' });
+    (global as any).allowedStatusTransitions = { assigned: ['in_transit', 'cancelled'] };
+    const { updateLoadStatusAction } = await import('../../../lib/actions/dispatchActions');
+    const res = await updateLoadStatusAction('org1', 'l1', 'in_transit');
+    expect(res.success).toBe(true);
+    expect(dbMock.load.update).toHaveBeenCalled();
+    expect(dbMock.loadStatusEvent.create).toHaveBeenCalled();
+  });
+
+  it('returns error for invalid status transition', async () => {
+    authMock.mockResolvedValue({ userId: 'u1' });
+    dbMock.load.findUnique.mockResolvedValue({ status: 'assigned' });
+    (global as any).allowedStatusTransitions = { assigned: ['in_transit', 'cancelled'] };
+    const { updateLoadStatusAction } = await import('../../../lib/actions/dispatchActions');
+    const res = await updateLoadStatusAction('org1', 'l1', 'delivered');
+    expect(res).toEqual({ success: false, error: 'Invalid status change' });
+    expect(dbMock.load.update).not.toHaveBeenCalled();
+  });
+
+  it('returns unauthorized when updating status without auth', async () => {
+    authMock.mockResolvedValue({ userId: null });
+    (global as any).allowedStatusTransitions = { assigned: ['in_transit', 'cancelled'] };
+    const { updateLoadStatusAction } = await import('../../../lib/actions/dispatchActions');
+    const res = await updateLoadStatusAction('org1', 'l1', 'in_transit');
+    expect(res).toEqual({ success: false, error: 'Unauthorized' });
+    expect(dbMock.load.findUnique).not.toHaveBeenCalled();
+  });
+});

--- a/tests/e2e/dispatch-create-load.spec.ts
+++ b/tests/e2e/dispatch-create-load.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+import { createTestAuth } from '../fixtures/auth';
+
+test.describe('Dispatch load creation', () => {
+  test('dispatcher creates load and sees it on board', async ({ page, context }) => {
+    const auth = createTestAuth(page, context);
+    await auth.loginAsDispatcher();
+
+    await page.goto('/org1/dispatch/loads/new');
+
+    await page.fill('#load_number', 'L-2001');
+    await page.click('text=Locations');
+    await page.fill('#origin_address', '123 Main St');
+    await page.fill('#origin_city', 'Springfield');
+    await page.fill('#origin_state', 'IL');
+    await page.fill('#origin_zip', '62704');
+    await page.fill('#destination_address', '456 Oak Ave');
+    await page.fill('#destination_city', 'Shelbyville');
+    await page.fill('#destination_state', 'IL');
+    await page.fill('#destination_zip', '62565');
+
+    await page.click('button[type="submit"]');
+
+    await expect(page).toHaveURL(/\/org1\/dispatch$/);
+    await expect(page.locator('text=L-2001')).toBeVisible({ timeout: 10000 });
+  });
+});


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: dispatch
Milestone: MVP

## Description
Adds comprehensive unit tests for dispatch actions covering load creation, status updates, and permission enforcement. Introduces a Playwright E2E test simulating a dispatcher creating a load and confirming its presence on the dispatch board.

## Related Issue
Closes #123 - [Dispatch] test: add load creation and board verification tests (MVP)

## Wave Dependencies
- Builds on: none
- Enables: expanded dispatch testing
- Cross-domain integration: none

## Domain Impact
- Primary domain: dispatch
- Files modified: `tests/domains/dispatch/dispatchActions.test.ts`, `tests/e2e/dispatch-create-load.spec.ts`
- Integration points: none

## Milestone Compliance
- [x] Meets MVP complexity requirements
- [x] Aligns with milestone delivery goals
- [x] No scope creep beyond milestone definition

## Wave Completion
- [x] Domain task completed for current wave
- [ ] Dependencies resolved or properly managed
- [ ] Ready for wave progression

## Testing Performed
- [x] Domain-specific functionality verified
- [ ] Cross-domain integrations tested
- [ ] Wave dependencies validated
- [x] Milestone requirements met


------
https://chatgpt.com/codex/tasks/task_e_6897400fd87c83279181705ddef93f40