### PR TITLE
[Vehicles] feat: add paginated vehicle loading (Core) (Closes #38)

### DIFF
--- a/app/(tenant)/[orgId]/vehicles/page.tsx
+++ b/app/(tenant)/[orgId]/vehicles/page.tsx
@@ -11,7 +11,13 @@ interface VehiclesPageProps {
 
 export default async function VehiclesPage({ params }: VehiclesPageProps) {
   const { orgId } = await params;
-  const { data } = await listVehiclesByOrg(orgId);
+  const PAGE_SIZE = 10;
+  const { data, totalPages } = await listVehiclesByOrg(orgId, 1, PAGE_SIZE);
+
+  async function fetchPage(page: number) {
+    'use server';
+    return await listVehiclesByOrg(orgId, page, PAGE_SIZE);
+  }
 
   return (
     <div className="flex flex-col gap-6 p-6 bg-neutral-900 text-white min-h-screen">
@@ -35,7 +41,13 @@ export default async function VehiclesPage({ params }: VehiclesPageProps) {
       </div>
 
       <Suspense fallback={<VehicleListSkeleton />}>
-        <VehiclesClient orgId={orgId} initialVehicles={data} />
+        <VehiclesClient
+          orgId={orgId}
+          initialVehicles={data}
+          initialPage={1}
+          totalPages={totalPages}
+          fetchPage={fetchPage}
+        />
       </Suspense>
     </div>
   );

--- a/app/(tenant)/[orgId]/vehicles/vehicles-client.tsx
+++ b/app/(tenant)/[orgId]/vehicles/vehicles-client.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
-import type { Vehicle } from '@/types/vehicles';
+import type { Vehicle, VehicleListResponse } from '@/types/vehicles';
 import { VehicleTable } from '@/components/vehicles/vehicle-table';
 import { VehicleCard } from '@/components/vehicles/vehicle-card';
 import { VehicleDetailsDialog } from '@/components/vehicles/vehicle-details-dialog';
@@ -11,13 +11,32 @@ import { Grid, List } from 'lucide-react';
 interface VehiclesClientProps {
   orgId: string;
   initialVehicles: Vehicle[];
+  initialPage: number;
+  totalPages: number;
+  fetchPage: (page: number) => Promise<VehicleListResponse>;
 }
 
-export default function VehiclesClient({ orgId, initialVehicles }: VehiclesClientProps) {
+export default function VehiclesClient({
+  orgId,
+  initialVehicles,
+  initialPage,
+  totalPages: initialTotalPages,
+  fetchPage,
+}: VehiclesClientProps) {
   const [vehicles, setVehicles] = useState(initialVehicles);
+  const [page, setPage] = useState(initialPage);
+  const [totalPages, setTotalPages] = useState(initialTotalPages);
   const [viewMode, setViewMode] = useState<'table' | 'grid'>('table');
   const [selectedVehicle, setSelectedVehicle] = useState<Vehicle | null>(null);
   const [detailsDialogOpen, setDetailsDialogOpen] = useState(false);
+
+  const handleLoadMore = async () => {
+    const nextPage = page + 1;
+    const res = await fetchPage(nextPage);
+    setVehicles((prev) => [...prev, ...res.data]);
+    setPage(nextPage);
+    setTotalPages(res.totalPages);
+  };
 
   const handleVehicleSelect = (vehicle: Vehicle) => {
     setSelectedVehicle(vehicle);
@@ -73,6 +92,12 @@ export default function VehiclesClient({ orgId, initialVehicles }: VehiclesClien
               onClick={() => handleVehicleSelect(vehicle)}
             />
           ))}
+        </div>
+      )}
+
+      {page < totalPages && (
+        <div className="flex justify-center">
+          <Button onClick={handleLoadMore}>Load More</Button>
         </div>
       )}
 

--- a/features/vehicles/VehicleListPage.tsx
+++ b/features/vehicles/VehicleListPage.tsx
@@ -23,10 +23,7 @@ export default async function VehicleListPage({
   orgId,
   page = 1,
 }: VehicleListPageProps) {
-  const { data } = await listVehiclesByOrg(orgId, {
-    page,
-    limit: 50,
-  });
+  const { data } = await listVehiclesByOrg(orgId, page, 50);
 
   return (
     <div className="flex flex-col gap-6 p-6 bg-neutral-900 text-white min-h-screen">


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: vehicles
Milestone: Core

## Description
Adds pagination parameters to vehicle fetcher and exposes client-side "Load More" loading for vehicle lists.

## Related Issue
Closes #38 - Vehicles Feature: Provide paginated vehicle listings (Core)

## Wave Dependencies
- Builds on: none
- Enables: client-side vehicle pagination
- Cross-domain integration: none

## Domain Impact
- Primary domain: vehicles
- Files modified: lib/fetchers/vehicleFetchers.ts, app/(tenant)/[orgId]/vehicles/page.tsx, app/(tenant)/[orgId]/vehicles/vehicles-client.tsx, features/vehicles/VehicleListPage.tsx
- Integration points: server actions for pagination

## Milestone Compliance
- [x] Meets Core complexity requirements
- [x] Aligns with milestone delivery goals
- [x] No scope creep beyond milestone definition

## Wave Completion
- [x] Domain task completed for current wave
- [x] Dependencies resolved or properly managed
- [x] Ready for wave progression

## Testing Performed
- [ ] Domain-specific functionality verified
- [ ] Cross-domain integrations tested
- [ ] Wave dependencies validated
- [ ] Milestone requirements met

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897400bfb688327a3a68e89768d2fe7