### PR TITLE
[Admin] feat: add onboarding wizard (MVP) (Closes #180)

### DIFF
--- a/app/(funnel)/onboarding/page.tsx
+++ b/app/(funnel)/onboarding/page.tsx
@@ -1,0 +1,9 @@
+import { OnboardingWizardFeature } from '@/features/admin/OnboardingWizardFeature';
+
+export default function AdminOnboardingPage() {
+  return (
+    <div className="container mx-auto py-10">
+      <OnboardingWizardFeature />
+    </div>
+  );
+}

--- a/features/admin/OnboardingWizardFeature.tsx
+++ b/features/admin/OnboardingWizardFeature.tsx
@@ -1,0 +1,225 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Progress } from '@/components/ui/progress';
+import { toast } from '@/hooks/use-toast';
+import { useOrganizationContext } from '@/components/auth/context';
+import { createOrganizationInvitation } from '@/lib/actions/invitationActions';
+import {
+  updateOrganizationSettings,
+  updateIntegrationSettings,
+} from '@/lib/actions/settingsActions';
+
+interface OrgData {
+  name: string;
+  timezone: string;
+}
+
+interface InviteData {
+  email: string;
+  role: string;
+}
+
+interface ConfigData {
+  notifications: boolean;
+}
+
+const steps = ['Organization', 'Invite Team', 'Settings'];
+
+export function OnboardingWizardFeature() {
+  const org = useOrganizationContext();
+  const router = useRouter();
+  const [step, setStep] = useState(0);
+  const [orgData, setOrgData] = useState<OrgData>({ name: '', timezone: '' });
+  const [inviteData, setInviteData] = useState<InviteData>({ email: '', role: 'member' });
+  const [configData, setConfigData] = useState<ConfigData>({ notifications: true });
+
+  const next = () => setStep((s) => Math.min(s + 1, steps.length - 1));
+  const prev = () => setStep((s) => Math.max(s - 1, 0));
+
+  const handleFinish = () => {
+    if (org?.id) {
+      router.push(`/${org.id}/dashboard`);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-xl space-y-6 py-10">
+      <Progress value={(step / (steps.length - 1)) * 100} />
+      {step === 0 && (
+        <OrgSetup
+          orgId={org?.id}
+          data={orgData}
+          onChange={setOrgData}
+          onNext={next}
+        />
+      )}
+      {step === 1 && (
+        <InviteTeam
+          data={inviteData}
+          onChange={setInviteData}
+          onPrev={prev}
+          onNext={next}
+        />
+      )}
+      {step === 2 && (
+        <ConfigureSettings
+          orgId={org?.id}
+          data={configData}
+          onChange={setConfigData}
+          onPrev={prev}
+          onFinish={handleFinish}
+        />
+      )}
+    </div>
+  );
+}
+
+function OrgSetup({
+  orgId,
+  data,
+  onChange,
+  onNext,
+}: {
+  orgId?: string;
+  data: OrgData;
+  onChange: (data: OrgData) => void;
+  onNext: () => void;
+}) {
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!orgId) return;
+    await updateOrganizationSettings(orgId, {
+      id: orgId,
+      name: data.name,
+      timezone: data.timezone,
+    });
+    toast({ title: 'Organization saved' });
+    onNext();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="org-name">Organization Name</Label>
+        <Input
+          id="org-name"
+          value={data.name}
+          onChange={(e) => onChange({ ...data, name: e.target.value })}
+          required
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="org-timezone">Timezone</Label>
+        <Input
+          id="org-timezone"
+          value={data.timezone}
+          onChange={(e) => onChange({ ...data, timezone: e.target.value })}
+          placeholder="UTC"
+          required
+        />
+      </div>
+      <Button type="submit">Save & Continue</Button>
+    </form>
+  );
+}
+
+function InviteTeam({
+  data,
+  onChange,
+  onPrev,
+  onNext,
+}: {
+  data: InviteData;
+  onChange: (data: InviteData) => void;
+  onPrev: () => void;
+  onNext: () => void;
+}) {
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await createOrganizationInvitation({
+      emailAddress: data.email,
+      role: data.role,
+    });
+    toast({ title: 'Invitation sent' });
+    onNext();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="invite-email">Team Member Email</Label>
+        <Input
+          id="invite-email"
+          type="email"
+          value={data.email}
+          onChange={(e) => onChange({ ...data, email: e.target.value })}
+          required
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="invite-role">Role</Label>
+        <Input
+          id="invite-role"
+          value={data.role}
+          onChange={(e) => onChange({ ...data, role: e.target.value })}
+        />
+      </div>
+      <div className="flex justify-between">
+        <Button type="button" variant="outline" onClick={onPrev}>
+          Back
+        </Button>
+        <Button type="submit">Send Invite</Button>
+      </div>
+    </form>
+  );
+}
+
+function ConfigureSettings({
+  orgId,
+  data,
+  onChange,
+  onPrev,
+  onFinish,
+}: {
+  orgId?: string;
+  data: ConfigData;
+  onChange: (data: ConfigData) => void;
+  onPrev: () => void;
+  onFinish: () => void;
+}) {
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!orgId) return;
+    await updateIntegrationSettings(orgId, {
+      notifications: data.notifications,
+    });
+    toast({ title: 'Settings updated' });
+    onFinish();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="flex items-center space-x-2">
+        <Switch
+          id="notifications"
+          checked={data.notifications}
+          onCheckedChange={(v) => onChange({ ...data, notifications: v })}
+        />
+        <Label htmlFor="notifications">Enable notifications</Label>
+      </div>
+      <div className="flex justify-between">
+        <Button type="button" variant="outline" onClick={onPrev}>
+          Back
+        </Button>
+        <Button type="submit">Finish</Button>
+      </div>
+    </form>
+  );
+}
+


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: admin
Milestone: MVP

## Description
Adds a simple onboarding wizard for new admins with steps for organization setup, inviting team members, and configuring basic settings.

## Related Issue
Closes #180 - [Admin] feat: add onboarding wizard (MVP)

## Wave Dependencies
- Builds on: none
- Enables: streamlined admin setup
- Cross-domain integration: settings, invitations

## Domain Impact
- Primary domain: admin
- Files modified: features/admin/OnboardingWizardFeature.tsx, app/(funnel)/onboarding/page.tsx
- Integration points: invitationActions, settingsActions

## Milestone Compliance
- [x] Meets MVP complexity requirements
- [x] Aligns with milestone delivery goals
- [x] No scope creep beyond milestone definition

## Wave Completion
- [x] Domain task completed for current wave
- [x] Dependencies resolved or properly managed
- [x] Ready for wave progression

## Testing Performed
- [ ] Domain-specific functionality verified
- [ ] Cross-domain integrations tested
- [ ] Wave dependencies validated
- [ ] Milestone requirements met

------
https://chatgpt.com/codex/tasks/task_e_68974356ee688327a3f62aaf27b01727