### PR TITLE
[Drivers] feat: Add mobile receipt logs (MVP) (Closes #38)

### DIFF
--- a/app/(mobile)/drivers/[userId]/logs/log-form.tsx
+++ b/app/(mobile)/drivers/[userId]/logs/log-form.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useState, useActionState } from 'react';
+import ImageUploader from '@/components/ImageUploader';
+import { createDriverLog } from '@/lib/actions/driver/logActions';
+import { Button } from '@/components/ui/button';
+
+interface LogFormProps {
+  userId: string;
+}
+
+interface ActionState {
+  success: boolean;
+  error?: string;
+}
+
+export default function LogForm({ userId }: LogFormProps) {
+  const [receiptUrl, setReceiptUrl] = useState('');
+  const [state, formAction] = useActionState<ActionState>(
+    async (_prev: ActionState, formData: FormData) => {
+      formData.set('driverId', userId);
+      formData.set('receiptUrl', receiptUrl);
+      const result = await createDriverLog(formData);
+      return result as ActionState;
+    },
+    { success: false },
+  );
+
+  return (
+    <form action={formAction} className="space-y-3">
+      <textarea
+        name="note"
+        className="w-full rounded border p-2 text-sm"
+        placeholder="Log description"
+      />
+      <ImageUploader onUpload={setReceiptUrl} />
+      <Button type="submit" className="w-full">Save Log</Button>
+      {state?.error && (
+        <p className="text-red-500 text-sm">{state.error}</p>
+      )}
+      {state?.success && !state.error && (
+        <p className="text-green-600 text-sm">Log saved successfully</p>
+      )}
+    </form>
+  );
+}

--- a/app/(mobile)/drivers/[userId]/logs/page.tsx
+++ b/app/(mobile)/drivers/[userId]/logs/page.tsx
@@ -1,0 +1,16 @@
+import LogForm from './log-form';
+
+interface PageProps {
+  params: Promise<{ userId: string }>;
+}
+
+export default async function DriverLogsPage({ params }: PageProps) {
+  const { userId } = await params;
+
+  return (
+    <div className="mx-auto max-w-md p-4 space-y-4">
+      <h1 className="text-lg font-semibold">Driver Logs</h1>
+      <LogForm userId={userId} />
+    </div>
+  );
+}

--- a/components/ImageUploader.tsx
+++ b/components/ImageUploader.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useState } from 'react';
+import { upload } from '@vercel/blob/client';
+
+interface ImageUploaderProps {
+  onUpload?: (url: string) => void;
+  className?: string;
+}
+
+export default function ImageUploader({ onUpload, className }: ImageUploaderProps) {
+  const [preview, setPreview] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+
+  async function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    setPreview(URL.createObjectURL(file));
+    setUploading(true);
+    try {
+      const { url } = await upload(`${Date.now()}-${file.name}`, file, {
+        access: 'public',
+        handleUploadUrl: '/api/files/upload',
+      });
+      onUpload?.(url);
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  return (
+    <div className={className}>
+      {preview && (
+        <img
+          src={preview}
+          alt="Receipt preview"
+          className="mb-2 h-40 w-full rounded object-cover"
+        />
+      )}
+      <div className="flex items-center gap-2">
+        <input
+          type="file"
+          accept="image/*"
+          onChange={handleChange}
+          className="text-sm"
+        />
+        {uploading && <span className="text-xs text-muted-foreground">Uploading...</span>}
+      </div>
+    </div>
+  );
+}
+

--- a/lib/actions/driver/logActions.ts
+++ b/lib/actions/driver/logActions.ts
@@ -1,0 +1,43 @@
+'use server';
+
+import { auth } from '@clerk/nextjs/server';
+import { revalidatePath } from 'next/cache';
+import { z } from 'zod';
+
+import db from '@/lib/database/db';
+import { handleError } from '@/lib/errors/handleError';
+
+const logSchema = z.object({
+  driverId: z.string().min(1),
+  note: z.string().min(1),
+  receiptUrl: z.string().url(),
+});
+
+export async function createDriverLog(formData: FormData) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return { success: false, error: 'Authentication required' };
+    }
+
+    const data = logSchema.parse({
+      driverId: formData.get('driverId'),
+      note: formData.get('note'),
+      receiptUrl: formData.get('receiptUrl'),
+    });
+
+    await db.driverLog.create({
+      data: {
+        driverId: data.driverId,
+        note: data.note,
+        receiptUrl: data.receiptUrl,
+      },
+    });
+
+    revalidatePath(`/drivers/${data.driverId}/logs`, 'page');
+
+    return { success: true };
+  } catch (error) {
+    return handleError(error, 'Create Driver Log');
+  }
+}


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: drivers
Milestone: MVP

## Description
Adds a mobile-optimized driver logs page with receipt image uploads and a server action to persist log entries.

## Related Issue
Closes #38 - [Drivers] Feature: Mobile receipt logs (MVP)

## Wave Dependencies
- Builds on: none
- Enables: future driver expense tracking
- Cross-domain integration: none

## Domain Impact
- Primary domain: drivers
- Files modified: app/(mobile)/drivers/[userId]/logs/page.tsx, components/ImageUploader.tsx, lib/actions/driver/logActions.ts
- Integration points: server actions & blob upload

## Milestone Compliance
- [x] Meets MVP complexity requirements
- [x] Aligns with milestone delivery goals
- [x] No scope creep beyond milestone definition

## Wave Completion
- [x] Domain task completed for current wave
- [ ] Dependencies resolved or properly managed
- [ ] Ready for wave progression

## Testing Performed
- [ ] Domain-specific functionality verified
- [ ] Cross-domain integrations tested
- [ ] Wave dependencies validated
- [ ] Milestone requirements met
- `npm test` (fails: module mocking and auth issues)


------
https://chatgpt.com/codex/tasks/task_e_68974348f5d08327bc63fd89177a1d69