### PR TITLE
[Dispatch] feat: add realtime load updates and driver map (Core) (Closes #38)

### DIFF
--- a/components/dispatch/driver-map.tsx
+++ b/components/dispatch/driver-map.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import type { Driver } from '@/types/drivers';
+
+interface DriverMapProps {
+  drivers: Driver[];
+}
+
+// Simple SVG map visualization focusing on US region
+export function DriverMap({ drivers }: DriverMapProps) {
+  const markers = drivers.filter(
+    (d) => d.currentLocation?.latitude !== undefined && d.currentLocation?.longitude !== undefined,
+  );
+
+  return (
+    <div className="relative h-64 w-full overflow-hidden rounded-lg bg-blue-50 dark:bg-blue-900">
+      <svg width="100%" height="100%" viewBox="0 0 800 400" className="border rounded">
+        <rect width="800" height="400" fill="#f0f9ff" className="dark:fill-gray-800" />
+        {markers.map((driver) => {
+          const lat = driver.currentLocation!.latitude;
+          const lng = driver.currentLocation!.longitude;
+          const x = ((lng + 130) / 60) * 800; // Map US longitudes -130 to -70
+          const y = ((50 - lat) / 25) * 400; // Map US latitudes 25 to 50
+          return (
+            <circle key={driver.id} cx={x} cy={y} r={5} fill="#3b82f6">
+              <title>{`${driver.firstName} ${driver.lastName}`}</title>
+            </circle>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}

--- a/features/dispatch/DispatchBoardFeature.tsx
+++ b/features/dispatch/DispatchBoardFeature.tsx
@@ -5,8 +5,10 @@ import type { Load, LoadStatus } from '@/types/dispatch';
 import type { Driver } from '@/types/drivers';
 import type { Vehicle } from '@/types/vehicles';
 import { DispatchBoardUI } from '@/components/dispatch/dispatch-board';
+import { DriverMap } from '@/components/dispatch/driver-map';
 import { useRouter } from 'next/navigation';
-import { updateLoadStatusAction } from '@/lib/actions/dispatchActions';
+import { useDispatchRealtime } from '@/hooks/use-dispatch-realtime';
+import { updateLoadStatusAction } from '@/lib/actions/dispatch/loadActions';
 
 interface DispatchBoardFeatureProps {
   loads: Load[];
@@ -20,7 +22,6 @@ interface DispatchBoardFeatureProps {
     origin?: string;
     destination?: string;
     dateRange?: string;
-    page?: string;
   };
 }
 
@@ -47,6 +48,7 @@ export function DispatchBoardFeature({
   searchParams = {},
 }: DispatchBoardFeatureProps) {
   const router = useRouter();
+  const { connectionStatus } = useDispatchRealtime({ orgId });
   const [isPending, startTransition] = useTransition();
 
   const currentTab = searchParams.tab || 'all';
@@ -140,6 +142,10 @@ export function DispatchBoardFeature({
 
   return (
     <div>
+      <div className="mb-4">
+        <DriverMap drivers={drivers} />
+        <p className="mt-2 text-xs text-gray-500">Realtime: {connectionStatus}</p>
+      </div>
       <DispatchBoardUI
         loads={loads}
         drivers={drivers}

--- a/lib/actions/dispatch/loadActions.ts
+++ b/lib/actions/dispatch/loadActions.ts
@@ -1,0 +1,72 @@
+'use server';
+
+import { auth } from '@clerk/nextjs/server';
+import { revalidatePath } from 'next/cache';
+import db from '@/lib/database/db';
+import { handleError } from '@/lib/errors/handleError';
+import type { DashboardActionResult } from '@/types/dashboard';
+import type { LoadStatus } from '@/types/dispatch';
+import { allowedStatusTransitions } from '@/lib/utils/dispatchStatus';
+
+/**
+ * Update load status and record status event.
+ */
+export async function updateLoadStatusAction(
+  orgId: string,
+  loadId: string,
+  newStatus: LoadStatus,
+): Promise<DashboardActionResult<{ id: string }>> {
+  try {
+    const { userId } = await auth();
+    if (!userId) return { success: false, error: 'Unauthorized' };
+
+    const current = await db.load.findUnique({
+      where: { id: loadId, organizationId: orgId },
+      select: { status: true },
+    });
+
+    if (!current) return { success: false, error: 'Load not found' };
+
+    const allowed = allowedStatusTransitions[current.status] || [];
+    if (!allowed.includes(newStatus)) {
+      return { success: false, error: 'Invalid status change' };
+    }
+
+    await db.load.update({
+      where: { id: loadId, organizationId: orgId },
+      data: {
+        status: newStatus,
+        lastModifiedBy: userId,
+        updatedAt: new Date(),
+      },
+    });
+
+    await db.loadStatusEvent.create({
+      data: {
+        loadId,
+        status: newStatus,
+        timestamp: new Date(),
+        automaticUpdate: false,
+        source: 'dispatcher',
+        createdBy: userId,
+      },
+    });
+
+    await db.dispatchActivity.create({
+      data: {
+        organizationId: orgId,
+        entityType: 'load',
+        action: 'status_change',
+        entityId: loadId,
+        userName: userId,
+        timestamp: new Date(),
+      },
+    });
+
+    // Revalidate dispatch views so the updated status is visible
+    revalidatePath(`/${orgId}/dispatch`, 'layout');
+    return { success: true, data: { id: loadId } };
+  } catch (error) {
+    return handleError(error, 'Update Load Status');
+  }
+}

--- a/lib/actions/dispatchActions.ts
+++ b/lib/actions/dispatchActions.ts
@@ -4,9 +4,9 @@ import { auth } from '@clerk/nextjs/server';
 import { revalidatePath } from 'next/cache';
 import db from '@/lib/database/db';
 import { handleError } from '@/lib/errors/handleError';
+import type { LoadActionResult } from '@/types/dispatch';
 import { loadInputSchema } from '@/schemas/dispatch';
 import type { DashboardActionResult } from '@/types/dashboard';
-import type { LoadStatus } from '@/types/dispatch';
 
 /**
  * Create a new load (dispatch)
@@ -227,65 +227,3 @@ export async function assignDriverToLoadAction(
   }
 }
 
-/**
- * Update status for a load
- */
-export async function updateLoadStatusAction(
-  orgId: string,
-  loadId: string,
-  newStatus: LoadStatus,
-): Promise<DashboardActionResult<{ id: string }>> {
-  try {
-    const { userId } = await auth();
-    if (!userId) return { success: false, error: 'Unauthorized' };
-
-    const current = await db.load.findUnique({
-      where: { id: loadId, organizationId: orgId },
-      select: { status: true },
-    });
-
-    if (!current) return { success: false, error: 'Load not found' };
-
-    const allowed = allowedStatusTransitions[current.status] || [];
-    if (!allowed.includes(newStatus)) {
-      return { success: false, error: 'Invalid status change' };
-    }
-
-    await db.load.update({
-      where: { id: loadId, organizationId: orgId },
-      data: {
-        status: newStatus,
-        lastModifiedBy: userId,
-        updatedAt: new Date(),
-      },
-    });
-
-    await db.loadStatusEvent.create({
-      data: {
-        loadId,
-        status: newStatus,
-        timestamp: new Date(),
-        automaticUpdate: false,
-        source: 'dispatcher',
-        createdBy: userId,
-      },
-    });
-
-    await db.dispatchActivity.create({
-      data: {
-        organizationId: orgId,
-        entityType: 'load',
-        action: 'status_change',
-        entityId: loadId,
-        userName: userId,
-        timestamp: new Date(),
-      },
-    });
-
-    // Revalidate dispatch views so the updated status is visible
-    revalidatePath(`/${orgId}/dispatch`, 'layout');
-    return { success: true, data: { id: loadId } };
-  } catch (error) {
-    return handleError(error, 'Update Load Status');
-  }
-}

--- a/tests/domains/dispatch/updateLoadStatusAction.test.ts
+++ b/tests/domains/dispatch/updateLoadStatusAction.test.ts
@@ -22,7 +22,7 @@ describe('updateLoadStatusAction', () => {
 
   it('updates status when transition is allowed', async () => {
     dbMock.load.findUnique.mockResolvedValue({ status: 'assigned' });
-    const { updateLoadStatusAction } = await import('../../../lib/actions/dispatchActions');
+    const { updateLoadStatusAction } = await import('../../../lib/actions/dispatch/loadActions');
     const res = await updateLoadStatusAction('org1', 'l1', 'in_transit');
     expect(res.success).toBe(true);
     expect(dbMock.load.update).toHaveBeenCalled();
@@ -31,7 +31,7 @@ describe('updateLoadStatusAction', () => {
 
   it('returns error for invalid transition', async () => {
     dbMock.load.findUnique.mockResolvedValue({ status: 'assigned' });
-    const { updateLoadStatusAction } = await import('../../../lib/actions/dispatchActions');
+    const { updateLoadStatusAction } = await import('../../../lib/actions/dispatch/loadActions');
     const res = await updateLoadStatusAction('org1', 'l1', 'delivered');
     expect(res).toEqual({ success: false, error: 'Invalid status change' });
     expect(dbMock.load.update).not.toHaveBeenCalled();


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: dispatch
Milestone: Core

## Description
- integrate server-sent events into dispatch board
- send load status updates through new dispatch load actions
- visualize driver coordinates on a lightweight map

## Related Issue
Closes #38 - Dispatch Feature: Realtime board updates (Core)

## Wave Dependencies
- Builds on: existing dispatch board and realtime hooks
- Enables: future live tracking features
- Cross-domain integration: drivers location data

## Domain Impact
- Primary domain: dispatch
- Files modified: features/dispatch/DispatchBoardFeature.tsx, lib/actions/dispatch/loadActions.ts
- Integration points: drivers location data

## Milestone Compliance
- [x] Meets Core complexity requirements
- [x] Aligns with milestone delivery goals
- [x] No scope creep beyond milestone definition

## Wave Completion
- [x] Domain task completed for current wave
- [ ] Dependencies resolved or properly managed
- [ ] Ready for wave progression

## Testing Performed
- [ ] Domain-specific functionality verified
- [ ] Cross-domain integrations tested
- [ ] Wave dependencies validated
- [ ] Milestone requirements met


------
https://chatgpt.com/codex/tasks/task_e_68974345aacc8327aff8b32b4dc1f898