### PR TITLE
[Settings] feat: add feature toggle switches (Core) (Closes #150)

### DIFF
--- a/features/settings/CompanySettingsPage.tsx
+++ b/features/settings/CompanySettingsPage.tsx
@@ -1,9 +1,17 @@
 import { getCompanyProfile } from '@/lib/fetchers/settingsFetchers';
 import { CompanyProfileForm } from '@/components/settings/CompanyProfileForm';
 import { updateCompanyProfileAction } from '@/lib/actions/settingsActions';
+import { FeatureToggleFeature } from '@/features/settings/FeatureToggleFeature';
+import { getTenantFeatureFlags } from '@/lib/tenantConfig';
 
 export default async function CompanySettingsPage({ orgId }: { orgId: string }) {
   const profile = await getCompanyProfile(orgId);
+  const flags = await getTenantFeatureFlags(orgId);
   // ...render form and handle submit with server action...
-  return <CompanyProfileForm profile={profile} onSubmit={() => {}} />;
+  return (
+    <>
+      <CompanyProfileForm profile={profile} onSubmit={() => {}} />
+      <FeatureToggleFeature orgId={orgId} flags={flags} />
+    </>
+  );
 }

--- a/features/settings/FeatureToggleFeature.tsx
+++ b/features/settings/FeatureToggleFeature.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useOptimistic } from 'react';
+import { Switch } from '@/components/ui/switch';
+import { updateFeatureToggle } from '@/lib/actions/settings/featureToggleActions';
+
+type FeatureToggleFeatureProps = {
+  orgId: string;
+  flags: Record<string, boolean>;
+};
+
+export function FeatureToggleFeature({ orgId, flags }: FeatureToggleFeatureProps) {
+  const [optimisticFlags, setOptimisticFlags] = useOptimistic(flags);
+
+  const handleToggle = async (feature: string, enabled: boolean) => {
+    setOptimisticFlags({ ...optimisticFlags, [feature]: enabled });
+    await updateFeatureToggle({ orgId, feature, enabled });
+  };
+
+  return (
+    <div className="space-y-4">
+      {Object.entries(optimisticFlags).map(([feature, enabled]) => (
+        <div key={feature} className="flex items-center justify-between">
+          <span className="capitalize">{feature}</span>
+          <Switch
+            checked={enabled}
+            onCheckedChange={(checked) => handleToggle(feature, checked)}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/features/settings/__tests__/FeatureToggleFeature.test.tsx
+++ b/features/settings/__tests__/FeatureToggleFeature.test.tsx
@@ -1,0 +1,18 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { FeatureToggleFeature } from '../FeatureToggleFeature';
+
+vi.mock('@/lib/actions/settings/featureToggleActions', () => ({
+  updateFeatureToggle: vi.fn(),
+}));
+
+describe('FeatureToggleFeature', () => {
+  it('calls action on toggle', async () => {
+    const { updateFeatureToggle } = await import('@/lib/actions/settings/featureToggleActions');
+    render(<FeatureToggleFeature orgId="org1" flags={{ demo: false }} />);
+    const toggle = screen.getByRole('switch');
+    fireEvent.click(toggle);
+    expect(updateFeatureToggle).toHaveBeenCalledWith({ orgId: 'org1', feature: 'demo', enabled: true });
+  });
+});

--- a/lib/actions/settings/featureToggleActions.ts
+++ b/lib/actions/settings/featureToggleActions.ts
@@ -1,0 +1,55 @@
+'use server';
+
+import { auth } from '@clerk/nextjs/server';
+import { revalidatePath } from 'next/cache';
+import db from '@/lib/database/db';
+import type { Prisma } from '@prisma/client';
+import { z } from 'zod';
+
+const FeatureToggleSchema = z.object({
+  orgId: z.string(),
+  feature: z.string(),
+  enabled: z.boolean(),
+});
+
+async function verifyOrgAccess(orgId: string) {
+  const { userId, orgId: sessionOrg } = await auth();
+  if (!userId || sessionOrg !== orgId) {
+    throw new Error('Unauthorized');
+  }
+  return userId;
+}
+
+async function logChange(orgId: string, userId: string, feature: string, enabled: boolean) {
+  await db.auditLog.create({
+    data: {
+      organizationId: orgId,
+      userId,
+      entityType: 'settings',
+      entityId: orgId,
+      action: `feature:${feature}:${enabled ? 'enabled' : 'disabled'}`,
+      timestamp: new Date(),
+    },
+  });
+}
+
+export async function updateFeatureToggle(data: unknown) {
+  const parsed = FeatureToggleSchema.parse(data);
+  const userId = await verifyOrgAccess(parsed.orgId);
+  const org = await db.organization.findUnique({ where: { id: parsed.orgId } });
+  const settings = (org?.settings as any) || {};
+  const featureFlags = settings.featureFlags || {};
+  featureFlags[parsed.feature] = parsed.enabled;
+  await db.organization.update({
+    where: { id: parsed.orgId },
+    data: {
+      settings: {
+        ...settings,
+        featureFlags,
+      } as Prisma.JsonObject,
+    },
+  });
+  await logChange(parsed.orgId, userId, parsed.feature, parsed.enabled);
+  revalidatePath(`/[orgId]/settings`);
+  return { success: true };
+}

--- a/lib/tenantConfig.ts
+++ b/lib/tenantConfig.ts
@@ -1,0 +1,14 @@
+'use server';
+
+import db from '@/lib/database/db';
+
+export async function getTenantFeatureFlags(orgId: string): Promise<Record<string, boolean>> {
+  const org = await db.organization.findUnique({ where: { id: orgId } });
+  const settings = (org?.settings as any) || {};
+  return settings.featureFlags || {};
+}
+
+export async function isFeatureEnabled(orgId: string, feature: string): Promise<boolean> {
+  const flags = await getTenantFeatureFlags(orgId);
+  return flags[feature] === true;
+}


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: settings
Milestone: Core

## Description
- add switch UI for tenant feature toggles
- persist toggle preferences through a settings action
- centralize tenant feature flag lookup

## Related Issue
Closes #150 - Settings feature: manage tenant feature toggles (Core)

## Wave Dependencies
- Builds on: existing settings actions
- Enables: runtime feature checks across domains
- Cross-domain integration: none

## Domain Impact
- Primary domain: settings
- Files modified: features/settings/FeatureToggleFeature.tsx, features/settings/CompanySettingsPage.tsx, lib/actions/settings/featureToggleActions.ts, lib/tenantConfig.ts
- Integration points: tenantConfig utility for runtime checks

## Milestone Compliance
- [x] Meets Core complexity requirements
- [x] Aligns with milestone delivery goals
- [x] No scope creep beyond milestone definition

## Wave Completion
- [x] Domain task completed for current wave
- [x] Dependencies resolved or properly managed
- [x] Ready for wave progression

## Testing Performed
- `npx vitest run features/settings/__tests__/FeatureToggleFeature.test.tsx`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm test` *(fails: multiple suites failing in repository)*


------
https://chatgpt.com/codex/tasks/task_e_6897434f4d608327af89bd42ed1f1ce7