### PR TITLE
Refactor dashboard data flow and audit log state

### DIFF
--- a/app/(tenant)/[orgId]/dashboard/[userId]/page.tsx
+++ b/app/(tenant)/[orgId]/dashboard/[userId]/page.tsx
@@ -6,7 +6,7 @@
 
 import React, { Suspense } from 'react';
 import { Activity, BarChart, CreditCard, FileText, Settings, Shield, Users } from 'lucide-react';
-import FleetOverviewHeader from '@/components/dashboard/fleet-overview-header';
+import FleetOverviewHeader from '@/features/dashboard/FleetOverviewHeader';
 import UserManagementDashboard from '@/features/dashboard/UserManagementDashboard';
 import { PageLayout } from '@/components/shared/PageLayout';
 import { DashboardSkeleton } from '@/components/dashboard/dashboard-skeleton';
@@ -48,7 +48,7 @@ export default async function DashboardPage({ params }: DashboardPageProps) {
     <PageLayout className="gap-3">
       {/* Fleet Overview Header */}
       <Suspense fallback={<DashboardSkeleton />}>
-        <FleetOverviewHeader orgId={orgId} userId={userId} />
+        <FleetOverviewHeader orgId={orgId} />
       </Suspense>
 
       {/* Main Admin Interface */}
@@ -175,12 +175,7 @@ export default async function DashboardPage({ params }: DashboardPageProps) {
             </CardHeader>
             <CardContent className="p-6 space-y-6">
               <Suspense fallback={<LoadingSpinner />}>
-                <AuditLogViewer
-                  logs={auditLogs}
-                  selectedLog={null}
-                  setSelectedLog={() => {}}
-                  getActionBadgeVariant={() => 'default'}
-                />
+                <AuditLogViewer logs={auditLogs} />
               </Suspense>
             </CardContent>
           </Card>

--- a/components/dashboard/fleet-overview-header.tsx
+++ b/components/dashboard/fleet-overview-header.tsx
@@ -1,15 +1,14 @@
 import { Card, CardContent } from '@/components/ui/card';
-import { getDashboardSummary } from '@/lib/fetchers/analyticsFetchers';
 import type { DashboardSummary } from '@/types/dashboard';
 import { RefreshCw, Home } from 'lucide-react';
 import React from 'react';
+
 interface FleetOverviewHeaderProps {
-  orgId: string;
-  userId: string; // <-- Add userId to props
+  summary: DashboardSummary | null;
 }
 
-export default async function FleetOverviewHeader({ orgId }: FleetOverviewHeaderProps) {
-  if (!orgId) {
+export default function FleetOverviewHeader({ summary }: FleetOverviewHeaderProps) {
+  if (!summary) {
     return (
       <Card className="border-red-200 bg-red-50">
         <CardContent className="p-4">
@@ -19,30 +18,14 @@ export default async function FleetOverviewHeader({ orgId }: FleetOverviewHeader
     );
   }
 
-  let summary: DashboardSummary | null = null;
-  let lastUpdated: string | null = null;
-
-  try {
-    const rawSummary = await getDashboardSummary(orgId);
-    // Ensure totalVehicles is present for kpi DashboardSummary
-    summary = {
-      ...rawSummary,
-      totalVehicles:
-        // Use activeVehicles as a proxy for total vehicles, since totalVehicles does not exist
-        rawSummary.activeVehicles ?? 0,
-    };
-    lastUpdated = summary?.lastUpdated
-      ? new Date(summary.lastUpdated).toLocaleString('en-US', {
-          month: 'short',
-          day: 'numeric',
-          hour: '2-digit',
-          minute: '2-digit',
-        })
-      : null;
-  } catch {
-    summary = null;
-    lastUpdated = null;
-  }
+  const lastUpdated = summary.lastUpdated
+    ? new Date(summary.lastUpdated).toLocaleString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      })
+    : null;
 
   return (
     <div className="flex flex-row items-baseline justify-between mb-6">

--- a/components/dashboard/organization-stats.tsx
+++ b/components/dashboard/organization-stats.tsx
@@ -1,7 +1,6 @@
 import {
   Users,
   Truck,
-  UserCheck,
   Package,
   Calendar,
   Activity,
@@ -10,15 +9,15 @@ import {
 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { getDashboardMetrics, getOrganizationStats } from '@/lib/fetchers/dashboardFetchers';
 import { Button } from '@/components/ui/button';
+import type { DashboardMetrics, OrganizationStats as OrgStats } from '@/types/dashboard';
 
-export async function OrganizationStats({ orgId, userId }: { orgId: string; userId?: string }) {
-  // Fetch metrics and stats in parallel
-  const [metrics, stats] = await Promise.all([
-    getDashboardMetrics(orgId, userId ?? ''), // Ensure userId is a string
-    getOrganizationStats(orgId),
-  ]);
+interface OrganizationStatsProps {
+  metrics: DashboardMetrics;
+  stats: OrgStats;
+}
+
+export function OrganizationStats({ metrics, stats }: OrganizationStatsProps) {
 
   // Calculate fleet utilization
   const fleetUtilization =

--- a/features/dashboard/AdminOverview.tsx
+++ b/features/dashboard/AdminOverview.tsx
@@ -1,12 +1,18 @@
 import { Suspense } from 'react';
 import { OrganizationStats } from '@/components/dashboard/organization-stats';
 import { DashboardSkeleton } from '@/components/dashboard/dashboard-skeleton';
+import { getDashboardMetrics, getOrganizationStats } from '@/lib/fetchers/dashboardFetchers';
 
 export default async function AdminOverview({ orgId, userId }: { orgId: string; userId: string }) {
+  const [metrics, stats] = await Promise.all([
+    getDashboardMetrics(orgId, userId),
+    getOrganizationStats(orgId),
+  ]);
+
   return (
     <div className="space-y-6">
       <Suspense fallback={<DashboardSkeleton />}>
-        <OrganizationStats orgId={orgId} userId={userId} />
+        <OrganizationStats metrics={metrics} stats={stats} />
       </Suspense>
     </div>
   );

--- a/features/dashboard/AuditLogViewer.tsx
+++ b/features/dashboard/AuditLogViewer.tsx
@@ -1,120 +1,37 @@
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog';
-import { Eye } from 'lucide-react';
+'use client';
+
+import { useState } from 'react';
+import { AuditLogTable } from '@/components/dashboard/audit-log-table';
 import type { AuditLogEntry } from '@/types/dashboard';
 
 interface AuditLogViewerProps {
   logs: AuditLogEntry[];
-  selectedLog: AuditLogEntry | null;
-  setSelectedLog: (log: AuditLogEntry | null) => void;
-  getActionBadgeVariant: (
-    action: string,
-  ) => 'default' | 'secondary' | 'destructive' | 'outline' | null | undefined;
 }
 
-export function AuditLogViewer({
-  logs,
-  selectedLog,
-  setSelectedLog,
-  getActionBadgeVariant,
-}: AuditLogViewerProps) {
+export function AuditLogViewer({ logs }: AuditLogViewerProps) {
+  const [selectedLog, setSelectedLog] = useState<AuditLogEntry | null>(null);
+
+  const getActionBadgeVariant = (
+    action: string,
+  ): 'default' | 'secondary' | 'destructive' | 'outline' | null | undefined => {
+    switch (action.toLowerCase()) {
+      case 'delete':
+        return 'destructive';
+      case 'update':
+        return 'secondary';
+      case 'create':
+        return 'outline';
+      default:
+        return 'default';
+    }
+  };
+
   return (
-    <div className="overflow-x-auto">
-      <table className="w-full">
-        <thead className="border-b border-gray-200 bg-neutral-900">
-          <tr>
-            <th className="text-left p-4 font-medium text-white">Date & Time</th>
-            <th className="text-left p-4 font-medium text-white">User</th>
-            <th className="text-left p-4 font-medium text-white">Action</th>
-            <th className="text-left p-4 font-medium text-white">Target</th>
-            <th className="text-left p-4 font-medium w-[100px] text-white">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          {logs.map((log, index) => (
-            <tr
-              key={log.id}
-              className={`border-b border-gray-700 hover:bg-neutral-800 ${index % 2 === 0 ? 'bg-black' : 'bg-neutral-900'}`}
-            >
-              <td className="p-4 font-mono text-sm text-gray-300">
-                {new Date(log.createdAt).toLocaleString()}
-              </td>
-              <td className="p-4">
-                <code className="text-sm bg-neutral-800 text-gray-300 px-2 py-1 rounded">
-                  {log.userId}
-                </code>
-              </td>
-              <td className="p-4">
-                <Badge variant={getActionBadgeVariant(log.action)}>{log.action}</Badge>
-              </td>
-              <td className="p-4 text-sm text-gray-300">{log.target}</td>
-              <td className="p-4">
-                <Dialog>
-                  <DialogTrigger asChild>
-                    <Button variant="ghost" size="sm" onClick={() => setSelectedLog(log)}>
-                      <Eye className="w-4 h-4" />
-                    </Button>
-                  </DialogTrigger>
-                  <DialogContent className="max-w-2xl">
-                    <DialogHeader>
-                      <DialogTitle>Audit Log Details</DialogTitle>
-                    </DialogHeader>
-                    {selectedLog && selectedLog.id === log.id && (
-                      <div className="space-y-4">
-                        <div className="grid grid-cols-2 gap-4">
-                          <div>
-                            <label className="text-sm font-medium text-muted-foreground">
-                              Timestamp
-                            </label>
-                            <p className="mt-1 font-mono text-sm">
-                              {new Date(selectedLog.createdAt).toISOString()}
-                            </p>
-                          </div>
-                          <div>
-                            <label className="text-sm font-medium text-muted-foreground">
-                              User ID
-                            </label>
-                            <p className="mt-1 font-mono text-sm">{selectedLog.userId}</p>
-                          </div>
-                          <div>
-                            <label className="text-sm font-medium text-muted-foreground">
-                              Action
-                            </label>
-                            <p className="mt-1">
-                              <Badge variant={getActionBadgeVariant(selectedLog.action)}>
-                                {selectedLog.action}
-                              </Badge>
-                            </p>
-                          </div>
-                          <div>
-                            <label className="text-sm font-medium text-muted-foreground">
-                              Target
-                            </label>
-                            <p className="mt-1 text-sm">{selectedLog.target}</p>
-                          </div>
-                        </div>
-                        <div>
-                          <label className="text-sm font-medium text-muted-foreground">
-                            Log ID
-                          </label>
-                          <p className="mt-1 font-mono text-sm break-all">{selectedLog.id}</p>
-                        </div>
-                      </div>
-                    )}
-                  </DialogContent>
-                </Dialog>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <AuditLogTable
+      logs={logs}
+      selectedLog={selectedLog}
+      setSelectedLog={setSelectedLog}
+      getActionBadgeVariant={getActionBadgeVariant}
+    />
   );
 }

--- a/features/dashboard/FleetOverviewHeader.tsx
+++ b/features/dashboard/FleetOverviewHeader.tsx
@@ -1,0 +1,18 @@
+import FleetOverviewHeader from '@/components/dashboard/fleet-overview-header';
+import { getDashboardSummary } from '@/lib/fetchers/analyticsFetchers';
+import type { DashboardSummary } from '@/types/dashboard';
+
+export default async function FleetOverviewHeaderFeature({ orgId }: { orgId: string }) {
+  let summary: DashboardSummary | null = null;
+  try {
+    const rawSummary = await getDashboardSummary(orgId);
+    summary = {
+      ...rawSummary,
+      totalVehicles: rawSummary.activeVehicles ?? 0,
+    };
+  } catch {
+    summary = null;
+  }
+
+  return <FleetOverviewHeader summary={summary} />;
+}

--- a/types/dashboard.ts
+++ b/types/dashboard.ts
@@ -189,11 +189,6 @@ export interface SystemHealthProps {
   initialData?: SystemHealthData;
 }
 
-export interface AuditLogViewerProps {
-  orgId: string;
-  initialLogs?: AuditLogEntry[];
-}
-
 export interface AuditLogTableProps {
   logs: AuditLogEntry[];
   selectedLog: AuditLogEntry | null;


### PR DESCRIPTION
## Summary
- Move dashboard metrics fetching from OrganizationStats component into AdminOverview feature
- Wrap fleet overview header in a feature that handles data retrieval
- Replace placeholder audit log handlers with stateful feature using AuditLogTable

## Testing
- `npm test` (failed: invalid Chai property, database connection, and other errors)
- `npm run lint` (failed: eslint config missing)


------
https://chatgpt.com/codex/tasks/task_e_6897875a4ad483278a49ea35c31d541c