### PR TITLE
refactor: centralize driver status helpers

### DIFF
--- a/app/(tenant)/[orgId]/drivers/[userId]/page.tsx
+++ b/app/(tenant)/[orgId]/drivers/[userId]/page.tsx
@@ -15,27 +15,13 @@ import Link from 'next/link';
 import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { PageLayout } from '@/components/shared/PageLayout';
+import { getDriverDisplayStatus, getDriverStatusColor } from '@/lib/utils/driverStatus';
 
 // Next.js 15 async params pattern
 interface PageProps {
   params: Promise<{ orgId: string; userId: string }>; // userId can be either user ID or driver ID
 }
 
-// Helper function to get status color
-function getStatusColor(status: string) {
-  switch (status) {
-    case 'active':
-      return 'bg-green-500/20 text-green-400 border-green-500/30';
-    case 'inactive':
-      return 'bg-red-500/20 text-red-400 border-red-500/30';
-    case 'suspended':
-      return 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30';
-    case 'terminated':
-      return 'bg-gray-500/20 text-gray-400 border-gray-500/30';
-    default:
-      return 'bg-gray-500/20 text-gray-400 border-gray-500/30';
-  }
-}
 
 export default async function DriverDashboardPage({ params }: PageProps) {
   const { orgId, userId } = await params;
@@ -76,8 +62,8 @@ export default async function DriverDashboardPage({ params }: PageProps) {
                 {driver.firstName} {driver.lastName}
               </h1>
               <div className="flex items-center gap-2">
-                <Badge className={getStatusColor(driver.status)}>
-                  {driver.status.replace('_', ' ')}
+                <Badge className={getDriverStatusColor(driver.status)}>
+                  {getDriverDisplayStatus(driver.status)}
                 </Badge>
                 {driver.companyName && (
                   <Badge

--- a/components/drivers/driver-card.tsx
+++ b/components/drivers/driver-card.tsx
@@ -1,8 +1,9 @@
 import { Phone, Mail, Calendar, FileText } from 'lucide-react';
-import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card';
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { formatDate } from '@/lib/utils/utils';
+import { getDriverDisplayStatus, getDriverStatusColor } from '@/lib/utils/driverStatus';
 import type { Driver } from '@/types/drivers';
 
 interface DriverCardProps {
@@ -11,51 +12,28 @@ interface DriverCardProps {
 }
 
 export function DriverCard({ driver, onClick }: DriverCardProps) {
-  const getStatusColor = (status: string) => {
-    // Map multiple statuses to active/inactive display
-    const isActive = ['available', 'assigned', 'driving', 'on_duty'].includes(status);
-    const isInactive = ['inactive', 'terminated'].includes(status);
-
-    if (isActive) {
-      return 'bg-green-500/20 text-green-400 border-green-500/30';
-    } else if (isInactive) {
-      return 'bg-red-500/20 text-red-400 border-red-500/30';
-    } else if (status === 'on_leave' || status === 'off_duty') {
-      return 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30';
-    } else {
-      return 'bg-gray-500/20 text-gray-400 border-gray-500/30';
-    }
-  };
-
-  const getDisplayStatus = (status: string) => {
-    const isActive = ['available', 'assigned', 'driving', 'on_duty'].includes(status);
-    const isInactive = ['inactive', 'terminated'].includes(status);
-
-    if (isActive) return 'active';
-    if (isInactive) return 'inactive';
-    return status.replace('_', ' ');
-  };
-
   const getInitials = (firstName: string, lastName: string) => {
     return `${firstName.charAt(0)}${lastName.charAt(0)}`;
   };
 
   return (
     <Card
-      className="border-muted rounded-md border bg-black hover:border-blue-500 transition-colors cursor-pointer"
+      className="rounded-md shadow-md border border-gray-200 bg-black hover:border-blue-500 transition-colors cursor-pointer"
       onClick={onClick}
     >
-      <CardHeader className="flex flex-row items-center gap-4 space-y-0 pb-2">
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 gap-4">
         <Avatar className="h-12 w-12 bg-blue-500/20 text-blue-400">
           <AvatarFallback className="bg-blue-500/20 text-blue-400">
             {getInitials(driver.firstName, driver.lastName)}
           </AvatarFallback>
         </Avatar>
         <div className="space-y-1">
-          <h3 className="leading-none font-medium text-white">
+          <CardTitle className="text-sm font-medium text-white">
             {driver.firstName} {driver.lastName}
-          </h3>
-          <Badge className={getStatusColor(driver.status)}>{getDisplayStatus(driver.status)}</Badge>
+          </CardTitle>
+          <Badge className={getDriverStatusColor(driver.status)}>
+            {getDriverDisplayStatus(driver.status)}
+          </Badge>
         </div>
       </CardHeader>
       <CardContent className="pb-2">

--- a/features/drivers/DriverDetailsDialog.tsx
+++ b/features/drivers/DriverDetailsDialog.tsx
@@ -34,6 +34,7 @@ import { updateDriverStatusAction } from '@/lib/actions/driverActions';
 import type { DriverStatus } from '@/types/drivers';
 import { toast } from '@/hooks/use-toast';
 import type { Driver } from '@/types/drivers';
+import { getDriverDisplayStatus, getDriverStatusColor } from '@/lib/utils/driverStatus';
 
 interface Load {
   id: string;
@@ -63,19 +64,6 @@ export function DriverDetailsDialog({
   orgId,
 }: DriverDetailsDialogProps) {
   const [isUpdatingStatus, setIsUpdatingStatus] = useState(false);
-
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case 'active':
-        return 'bg-green-500/20 text-green-400 border-green-500/30';
-      case 'inactive':
-        return 'bg-red-500/20 text-red-400 border-red-500/30';
-      case 'on_leave':
-        return 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30';
-      default:
-        return 'bg-gray-500/20 text-gray-400 border-gray-500/30';
-    }
-  };
 
   const getInitials = (firstName: string, lastName: string) => {
     return `${firstName.charAt(0)}${lastName.charAt(0)}`;
@@ -177,8 +165,8 @@ export function DriverDetailsDialog({
               </div>
             </div>
             <div className="flex items-center gap-2">
-              <Badge className={getStatusColor(driver.status)}>
-                {driver.status.replace('_', ' ')}
+              <Badge className={getDriverStatusColor(driver.status)}>
+                {getDriverDisplayStatus(driver.status)}
               </Badge>
             </div>
           </div>

--- a/lib/utils/driverStatus.ts
+++ b/lib/utils/driverStatus.ts
@@ -1,0 +1,28 @@
+import type { DriverStatus } from '@/types/drivers';
+
+const activeStatuses: DriverStatus[] = ['available', 'assigned', 'driving', 'on_duty', 'active'];
+const inactiveStatuses: DriverStatus[] = ['inactive', 'terminated'];
+const warningStatuses: DriverStatus[] = ['on_leave', 'off_duty', 'suspended'];
+
+export function getDriverStatusColor(status: string): string {
+  if (activeStatuses.includes(status as DriverStatus)) {
+    return 'bg-green-500/20 text-green-400 border-green-500/30';
+  }
+  if (inactiveStatuses.includes(status as DriverStatus)) {
+    return 'bg-red-500/20 text-red-400 border-red-500/30';
+  }
+  if (warningStatuses.includes(status as DriverStatus)) {
+    return 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30';
+  }
+  return 'bg-gray-500/20 text-gray-400 border-gray-500/30';
+}
+
+export function getDriverDisplayStatus(status: string): string {
+  if (activeStatuses.includes(status as DriverStatus)) {
+    return 'active';
+  }
+  if (inactiveStatuses.includes(status as DriverStatus)) {
+    return 'inactive';
+  }
+  return status.replace('_', ' ');
+}


### PR DESCRIPTION
## Summary
- add reusable driver status utilities for color and display
- update driver card, details dialog, and dashboard page to use shared helpers
- normalize driver card styling to design standards

## Testing
- `npm test` *(fails: module mocking and environment errors)*

------
https://chatgpt.com/codex/tasks/task_e_6897877ef0b08327af0a8ea76f98d4bd