### PR TITLE
chore: tighten test config and mocking

### DIFF
--- a/features/settings/__tests__/CompanySettingsPage.test.tsx
+++ b/features/settings/__tests__/CompanySettingsPage.test.tsx
@@ -8,9 +8,15 @@ import CompanySettingsPage from '../CompanySettingsPage';
 vi.mock('@/lib/fetchers/settingsFetchers', () => ({
   getCompanyProfile: vi.fn(async () => ({ name: 'Acme Inc.' })),
 }));
+vi.mock('@/lib/tenantConfig', () => ({
+  getTenantFeatureFlags: vi.fn(async () => ({})),
+}));
 
 vi.mock('@/components/settings/CompanyProfileForm', () => ({
   CompanyProfileForm: ({ profile }: any) => <form>Profile: {profile.name}</form>,
+}));
+vi.mock('../FeatureToggleFeature', () => ({
+  FeatureToggleFeature: () => <div>Feature toggles</div>,
 }));
 
 describe('CompanySettingsPage', () => {

--- a/features/settings/__tests__/FeatureToggleFeature.test.tsx
+++ b/features/settings/__tests__/FeatureToggleFeature.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { FeatureToggleFeature } from '../FeatureToggleFeature';
 
@@ -12,7 +13,8 @@ describe('FeatureToggleFeature', () => {
     const { updateFeatureToggle } = await import('@/lib/actions/settings/featureToggleActions');
     render(<FeatureToggleFeature orgId="org1" flags={{ demo: false }} />);
     const toggle = screen.getByRole('switch');
-    fireEvent.click(toggle);
+    const user = userEvent.setup();
+    await user.click(toggle);
     expect(updateFeatureToggle).toHaveBeenCalledWith({ orgId: 'org1', feature: 'demo', enabled: true });
   });
 });

--- a/tests/domains/admin/cancel-subscription.test.ts
+++ b/tests/domains/admin/cancel-subscription.test.ts
@@ -4,10 +4,10 @@ import { cancelSubscriptionAction } from '../../../lib/actions/dashboardActions'
 
 vi.mock('@clerk/nextjs/server', () => ({ auth: () => Promise.resolve({ userId: 'u1' }) }));
 
-const dbMock = {
+const dbMock = vi.hoisted(() => ({
   user: { findUnique: vi.fn().mockResolvedValue({ organizationId: 'org1', role: 'admin' }) },
   organization: { update: vi.fn().mockResolvedValue({ id: 'org1' }) },
-};
+}));
 vi.mock('../../../lib/database/db', () => ({ __esModule: true, default: dbMock }));
 vi.mock('../../../lib/errors/handleError', () => ({
   handleError: (e: any) => ({ success: false, error: String(e) }),

--- a/tests/domains/admin/export-organization-data.test.ts
+++ b/tests/domains/admin/export-organization-data.test.ts
@@ -7,7 +7,7 @@ vi.mock('@clerk/nextjs/server', () => ({ auth: () => Promise.resolve({ userId: '
 const putMock = vi.fn(async () => ({ downloadUrl: 'https://blob/test.csv' }));
 vi.mock('@vercel/blob', () => ({ put: putMock }));
 
-const dbMock = {
+const dbMock = vi.hoisted(() => ({
   user: {
     findMany: vi
       .fn()
@@ -16,7 +16,7 @@ const dbMock = {
       ]),
   },
   vehicle: { findMany: vi.fn().mockResolvedValue([]) },
-};
+}));
 vi.mock('../../../lib/database/db', () => ({ __esModule: true, default: dbMock }));
 vi.mock('../../../lib/errors/handleError', () => ({
   handleError: (e: any) => ({ success: false, error: String(e) }),

--- a/tests/domains/compliance/auditLogActions.test.ts
+++ b/tests/domains/compliance/auditLogActions.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createAuditLog } from '../../../lib/actions/auditLogActions';
 
-vi.mock('../lib/database/db', () => ({
+vi.mock('../../../lib/database/db', () => ({
   __esModule: true,
   default: { auditLog: { create: vi.fn() } },
 }));

--- a/tests/domains/dispatch/dispatchActions.test.ts
+++ b/tests/domains/dispatch/dispatchActions.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }));
 
-const authMock = vi.fn();
+const authMock = vi.hoisted(() => vi.fn());
 vi.mock('@clerk/nextjs/server', () => ({ auth: authMock }));
 
-const dbMock = {
+const dbMock = vi.hoisted(() => ({
   load: {
     create: vi.fn(),
     findUnique: vi.fn(),
@@ -13,7 +13,7 @@ const dbMock = {
   },
   loadStatusEvent: { create: vi.fn() },
   dispatchActivity: { create: vi.fn() },
-};
+}));
 
 vi.mock('../../../lib/database/db', () => ({ __esModule: true, default: dbMock }));
 vi.mock('../../../lib/errors/handleError', () => ({ handleError: vi.fn() }));

--- a/tests/domains/dispatch/loadForm.test.tsx
+++ b/tests/domains/dispatch/loadForm.test.tsx
@@ -2,6 +2,11 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { LoadForm } from '@/components/dispatch/load-form';
 import React from 'react';
+import { vi } from 'vitest';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
+}));
 
 describe('LoadForm validation', () => {
   it('shows validation errors for required fields', async () => {

--- a/tests/domains/dispatch/updateLoadStatusAction.test.ts
+++ b/tests/domains/dispatch/updateLoadStatusAction.test.ts
@@ -3,14 +3,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }));
 vi.mock('@clerk/nextjs/server', () => ({ auth: () => Promise.resolve({ userId: 'u1' }) }));
 
-const dbMock = {
+const dbMock = vi.hoisted(() => ({
   load: {
     findUnique: vi.fn(),
     update: vi.fn().mockResolvedValue({ id: 'l1' }),
   },
   loadStatusEvent: { create: vi.fn() },
   dispatchActivity: { create: vi.fn() },
-};
+}));
 
 vi.mock('../../../lib/database/db', () => ({ __esModule: true, default: dbMock }));
 vi.mock('../../../lib/errors/handleError', () => ({ handleError: vi.fn() }));

--- a/tests/domains/vehicles/vehicleActions.test.ts
+++ b/tests/domains/vehicles/vehicleActions.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as actions from '../../../lib/actions/vehicleActions';
 
 vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }));
-vi.mock('../lib/database/db', () => ({
+vi.mock('../../../lib/database/db', () => ({
   __esModule: true,
   default: {
     vehicle: {

--- a/tests/lib/auth/auth.test.ts
+++ b/tests/lib/auth/auth.test.ts
@@ -127,14 +127,17 @@ describe('auth.ts', () => {
     });
   });
 
-  describe('checkUserRole', async () => {
+  describe('checkUserRole', () => {
     it('returns false if no user', async () => {
       vi.spyOn(authModule, 'getCurrentUser').mockResolvedValue(null);
       const result = await authModule.checkUserRole('admin');
       expect(result).toBe(false);
     });
 
-    const result = await authModule.checkUserRole('admin');
-    expect(result).toBe(true);
+    it('returns true for matching role', async () => {
+      vi.spyOn(authModule, 'getCurrentUser').mockResolvedValue({ role: 'admin' } as any);
+      const result = await authModule.checkUserRole('admin');
+      expect(result).toBe(true);
+    });
   });
 });

--- a/tests/lib/onboarding/validateInvite.test.ts
+++ b/tests/lib/onboarding/validateInvite.test.ts
@@ -2,20 +2,18 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { validateInvite } from '../../../lib/actions/onboardingActions';
 
-let membershipMock: { findUnique: ReturnType<typeof vi.fn> };
-let invitationMock: { findUnique: ReturnType<typeof vi.fn> };
+const { membershipMock, invitationMock } = vi.hoisted(() => ({
+  membershipMock: { findUnique: vi.fn() },
+  invitationMock: { findUnique: vi.fn() },
+}));
 
-vi.mock('../../../lib/database/db', () => {
-  membershipMock = { findUnique: vi.fn() };
-  invitationMock = { findUnique: vi.fn() };
-  return {
-    __esModule: true,
-    default: {
-      organizationMembership: membershipMock,
-      organizationInvitation: invitationMock,
-    },
-  };
-});
+vi.mock('../../../lib/database/db', () => ({
+  __esModule: true,
+  default: {
+    organizationMembership: membershipMock,
+    organizationInvitation: invitationMock,
+  },
+}));
 
 describe('validateInvite', () => {
   beforeEach(() => {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     exclude: ['tests/e2e/**', 'tests/**/*.spec.ts', 'node_modules/**'],
     environment: 'jsdom',
     globals: true,
+    setupFiles: ['tests/setup.ts'],
     retry: process.env.CI ? 2 : 0,
     testTimeout: 30000,
     coverage: {


### PR DESCRIPTION
## Summary
- register global `@testing-library/jest-dom` setup for Vitest
- fix inconsistent mocks with `vi.hoisted` and corrected paths
- stabilize settings feature tests by mocking data and using `userEvent`

## Testing
- `npm test` *(fails: ReferenceError, TypeError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689b4771e2688327839476b331e7ee60